### PR TITLE
네비게이션 바 초초초보자 표현 수정 - #10

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ nav:
   - Home: index.md
   - 행동 규칙 : Hacktoberfest_code_of_conduct.md
   - 스팸 PR 관련 공지: hacktoberfest_spam_update.md
-  - 초초초보자용 가이드: super_beginners_guide.md
+  - 왕초보자용 가이드: super_beginners_guide.md
   - 초보자용 가이드: beginners_guide.md
   - 작업환경 구성 방법: build.md
   - 자주 묻는 질문: faq.md


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/38152182/96864091-dc681c00-14a2-11eb-9a24-2bbb4a8a4636.png)

왼쪽 네비게이션 바에 표시되던 **초초초보자용 가이드** 메뉴명을 **왕초보자용 가이드**로 수정했습니다.