### PR TITLE
우리집 인터넷 익스플로러에서는 링크가 다 평문처럼 보인다. #60

### DIFF
--- a/docs/javascript/ie_compatibility.js
+++ b/docs/javascript/ie_compatibility.js
@@ -1,0 +1,1 @@
+var agent = navigator.userAgent.toLowerCase(); if ( (navigator.appName == 'Netscape' && navigator.userAgent.search('Trident') != -1) || (agent.indexOf("msie") != -1) ) {document.write("<link rel='stylesheet' href='stylesheets/ie_compatibility.css'>");}

--- a/docs/stylesheets/ie_compatibility.css
+++ b/docs/stylesheets/ie_compatibility.css
@@ -1,0 +1,4561 @@
+
+@charset "UTF-8";html {
+    -webkit-text-size-adjust: none;
+    -moz-text-size-adjust: none;
+    -ms-text-size-adjust: none;
+    text-size-adjust: none;
+    box-sizing: border-box
+}
+
+*,:after,:before {
+    box-sizing: inherit
+}
+
+body {
+    margin: 0
+}
+
+a,button,input,label {
+    -webkit-tap-highlight-color: transparent
+}
+
+a {
+    color: inherit;
+    text-decoration: none
+}
+
+hr {
+    border: 0;
+    box-sizing: content-box;
+    display: block;
+    height: .05rem;
+    overflow: visible;
+    padding: 0
+}
+
+small {
+    font-size: 80%
+}
+
+sub,sup {
+    line-height: 1em
+}
+
+img {
+    border-style: none
+}
+
+table {
+    border-collapse: separate;
+    border-spacing: 0
+}
+
+td,th {
+    font-weight: 400;
+    vertical-align: top
+}
+
+button {
+    background: transparent;
+    border: 0;
+    font-family: inherit;
+    font-size: inherit;
+    margin: 0;
+    padding: 0
+}
+
+input {
+    border: 0;
+    outline: none
+}
+
+.md-icon svg {
+    fill: currentColor;
+    display: block;
+    height: 1.2rem;
+    width: 1.2rem
+}
+
+body {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale
+}
+
+body,input {
+    font-feature-settings: "kern","liga";
+    font-family: Roboto,-apple-system,BlinkMacSystemFont,Helvetica,Arial,sans-serif
+}
+
+body,code,input,kbd,pre {
+    color: rgba(0,0,0,0.87);
+}
+
+code,kbd,pre {
+    font-feature-settings: "kern";
+    font-family: Roboto Mono,SFMono-Regular,Consolas,Menlo,monospace
+}
+
+.md-typeset {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+    font-size: .8rem;
+    line-height: 1.6
+}
+
+@media print {
+    .md-typeset {
+        font-size: .68rem
+    }
+}
+
+.md-typeset blockquote,.md-typeset dl,.md-typeset figure,.md-typeset ol,.md-typeset pre,.md-typeset ul {
+    margin: 1em 0
+}
+
+.md-typeset h1 {
+    color: rgba(0,0,0,0.54);
+    font-size: 2em;
+    line-height: 1.3;
+    margin: 0 0 1.25em
+}
+
+.md-typeset h1,.md-typeset h2 {
+    font-weight: 300;
+    letter-spacing: -.01em
+}
+
+.md-typeset h2 {
+    font-size: 1.5625em;
+    line-height: 1.4;
+    margin: 1.6em 0 .64em
+}
+
+.md-typeset h3 {
+    font-size: 1.25em;
+    font-weight: 400;
+    letter-spacing: -.01em;
+    line-height: 1.5;
+    margin: 1.6em 0 .8em
+}
+
+.md-typeset h2+h3 {
+    margin-top: .8em
+}
+
+.md-typeset h4 {
+    font-weight: 700;
+    letter-spacing: -.01em;
+    margin: 1em 0
+}
+
+.md-typeset h5,.md-typeset h6 {
+    color: rgba(0,0,0,0.54);
+    font-size: .8em;
+    font-weight: 700;
+    letter-spacing: -.01em;
+    margin: 1.25em 0
+}
+
+.md-typeset h5 {
+    text-transform: uppercase
+}
+
+.md-typeset hr {
+    border-bottom: .05rem solid rgba(0,0,0,0.07);
+    display: flow-root;
+    margin: 1.5em 0
+}
+
+.md-typeset a {
+    color: #ef5552;
+    word-break: break-word
+}
+
+.md-typeset a,.md-typeset a:before {
+    transition: color 125ms
+}
+
+.md-typeset a:focus,.md-typeset a:hover {
+    color: #526cfe
+}
+
+.md-typeset a.focus-visible {
+    outline-color: #526cfe;
+    outline-offset: .2rem
+}
+
+.md-typeset code,.md-typeset kbd,.md-typeset pre {
+    color: #36464e;
+    direction: ltr
+}
+
+@media print {
+    .md-typeset code,.md-typeset kbd,.md-typeset pre {
+        white-space: pre-wrap
+    }
+}
+
+.md-typeset code {
+    background-color: #f5f5f5;
+    border-radius: .1rem;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    font-size: .85em;
+    padding: 0 .2941176471em;
+    word-break: break-word
+}
+
+.md-typeset code:not(.focus-visible) {
+    -webkit-tap-highlight-color: transparent;
+    outline: none
+}
+
+.md-typeset h1 code,.md-typeset h2 code,.md-typeset h3 code,.md-typeset h4 code,.md-typeset h5 code,.md-typeset h6 code {
+    background-color: transparent;
+    box-shadow: none;
+    margin: initial;
+    padding: initial
+}
+
+.md-typeset a code {
+    color: currentColor
+}
+
+.md-typeset pre {
+    display: flow-root;
+    line-height: 1.4;
+    position: relative
+}
+
+.md-typeset pre>code {
+    -webkit-box-decoration-break: slice;
+    box-decoration-break: slice;
+    box-shadow: none;
+    display: block;
+    margin: 0;
+    overflow: auto;
+    padding: .7720588235em 1.1764705882em;
+    scrollbar-color: rgba(0,0,0,0.32) transparent;
+    scrollbar-width: thin;
+    touch-action: auto;
+    word-break: normal
+}
+
+.md-typeset pre>code:hover {
+    scrollbar-color: #526cfe transparent
+}
+
+.md-typeset pre>code::-webkit-scrollbar {
+    height: .2rem;
+    width: .2rem
+}
+
+.md-typeset pre>code::-webkit-scrollbar-thumb {
+    background-color: rgba(0,0,0,0.32)
+}
+
+.md-typeset pre>code::-webkit-scrollbar-thumb:hover {
+    background-color: #526cfe
+}
+
+@media screen and (max-width: 44.9375em) {
+    .md-typeset>pre {
+        margin:1em -.8rem
+    }
+
+    .md-typeset>pre code {
+        border-radius: 0
+    }
+}
+
+.md-typeset kbd {
+    background-color: #fafafa;
+    border-radius: .1rem;
+    box-shadow: 0 .1rem 0 .05rem #b8b8b8,0 .1rem 0 #b8b8b8,0 -.1rem .2rem #fff inset;
+    color: rgba(0,0,0,0.87);
+    display: inline-block;
+    font-size: .75em;
+    padding: 0 .6666666667em;
+    vertical-align: text-top;
+    word-break: break-word
+}
+
+.md-typeset mark {
+    background-color: rgba(255,255,0,0.5);
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    color: inherit;
+    word-break: break-word
+}
+
+.md-typeset abbr {
+    border-bottom: .05rem dotted rgba(0,0,0,0.54);
+    cursor: help;
+    text-decoration: none
+}
+
+@media (hover: none) {
+    .md-typeset abbr {
+        position:relative
+    }
+
+    .md-typeset abbr[title]:focus:after,.md-typeset abbr[title]:hover:after {
+        background-color: rgba(0,0,0,0.87);
+        border-radius: .1rem;
+        box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12),0 3px 1px -2px rgba(0,0,0,.2);
+        color: #fff;
+        content: attr(title);
+        display: inline-block;
+        font-size: .7rem;
+        left: 0;
+        margin-top: 2em;
+        max-width: 80%;
+        min-width: -webkit-max-content;
+        min-width: -moz-max-content;
+        min-width: max-content;
+        padding: .2rem .3rem;
+        position: absolute;
+        width: auto
+    }
+}
+
+.md-typeset small {
+    opacity: .75
+}
+
+.md-typeset sub,.md-typeset sup {
+    margin-left: .078125em
+}
+
+[dir=rtl] .md-typeset sub,[dir=rtl] .md-typeset sup {
+    margin-left: 0;
+    margin-right: .078125em
+}
+
+.md-typeset blockquote {
+    border-left: .2rem solid rgba(0,0,0,0.32);
+    color: rgba(0,0,0,0.54);
+    padding-left: .6rem
+}
+
+[dir=rtl] .md-typeset blockquote {
+    border-left: initial;
+    border-right: .2rem solid rgba(0,0,0,0.32);
+    padding-left: 0;
+    padding-right: .6rem
+}
+
+.md-typeset ul {
+    list-style-type: disc
+}
+
+.md-typeset ol,.md-typeset ul {
+    display: flow-root;
+    margin-left: .625em;
+    padding: 0
+}
+
+[dir=rtl] .md-typeset ol,[dir=rtl] .md-typeset ul {
+    margin-left: 0;
+    margin-right: .625em
+}
+
+.md-typeset ol ol,.md-typeset ul ol {
+    list-style-type: lower-alpha
+}
+
+.md-typeset ol ol ol,.md-typeset ul ol ol {
+    list-style-type: lower-roman
+}
+
+.md-typeset ol li,.md-typeset ul li {
+    margin-bottom: .5em;
+    margin-left: 1.25em
+}
+
+[dir=rtl] .md-typeset ol li,[dir=rtl] .md-typeset ul li {
+    margin-left: 0;
+    margin-right: 1.25em
+}
+
+.md-typeset ol li blockquote,.md-typeset ol li p,.md-typeset ul li blockquote,.md-typeset ul li p {
+    margin: .5em 0
+}
+
+.md-typeset ol li:last-child,.md-typeset ul li:last-child {
+    margin-bottom: 0
+}
+
+.md-typeset ol li ol,.md-typeset ol li ul,.md-typeset ul li ol,.md-typeset ul li ul {
+    margin: .5em 0 .5em .625em
+}
+
+[dir=rtl] .md-typeset ol li ol,[dir=rtl] .md-typeset ol li ul,[dir=rtl] .md-typeset ul li ol,[dir=rtl] .md-typeset ul li ul {
+    margin-left: 0;
+    margin-right: .625em
+}
+
+.md-typeset dd {
+    margin: 1em 0 1.5em 1.875em
+}
+
+[dir=rtl] .md-typeset dd {
+    margin-left: 0;
+    margin-right: 1.875em
+}
+
+.md-typeset img,.md-typeset svg {
+    height: auto;
+    max-width: 100%
+}
+
+.md-typeset img[align=left],.md-typeset svg[align=left] {
+    margin: 1em 1em 1em 0
+}
+
+.md-typeset img[align=right],.md-typeset svg[align=right] {
+    margin: 1em 0 1em 1em
+}
+
+.md-typeset img[align]:only-child,.md-typeset svg[align]:only-child {
+    margin-top: 0
+}
+
+.md-typeset figure {
+    display: flow-root;
+    margin: 0 auto;
+    max-width: 100%;
+    text-align: center;
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
+    width: fit-content
+}
+
+.md-typeset figure img {
+    display: block
+}
+
+.md-typeset figcaption {
+    font-style: italic;
+    margin: 1em auto 2em;
+    max-width: 24rem
+}
+
+.md-typeset iframe {
+    max-width: 100%
+}
+
+.md-typeset table:not([class]) {
+    background-color: #fff;
+    border: .05rem solid rgba(0,0,0,0.12);
+    border-radius: .1rem;
+    display: inline-block;
+    font-size: .64rem;
+    max-width: 100%;
+    overflow: auto;
+    touch-action: auto
+}
+
+@media print {
+    .md-typeset table:not([class]) {
+        display: table
+    }
+}
+
+.md-typeset table:not([class])+* {
+    margin-top: 1.5em
+}
+
+.md-typeset table:not([class]) td>:first-child,.md-typeset table:not([class]) th>:first-child {
+    margin-top: 0
+}
+
+.md-typeset table:not([class]) td>:last-child,.md-typeset table:not([class]) th>:last-child {
+    margin-bottom: 0
+}
+
+.md-typeset table:not([class]) td:not([align]),.md-typeset table:not([class]) th:not([align]) {
+    text-align: left
+}
+
+[dir=rtl] .md-typeset table:not([class]) td:not([align]),[dir=rtl] .md-typeset table:not([class]) th:not([align]) {
+    text-align: right
+}
+
+.md-typeset table:not([class]) th {
+    font-weight: 700;
+    min-width: 5rem;
+    padding: .9375em 1.25em;
+    vertical-align: top
+}
+
+.md-typeset table:not([class]) th a {
+    color: inherit
+}
+
+.md-typeset table:not([class]) td {
+    border-top: .05rem solid rgba(0,0,0,0.12);
+    padding: .9375em 1.25em;
+    vertical-align: top
+}
+
+.md-typeset table:not([class]) tbody tr {
+    transition: background-color 125ms
+}
+
+.md-typeset table:not([class]) tbody tr:hover {
+    background-color: rgba(0,0,0,.035);
+    box-shadow: 0 .05rem 0 #fff inset
+}
+
+.md-typeset table:not([class]) a {
+    word-break: normal
+}
+
+.md-typeset table th[role=columnheader] {
+    cursor: pointer
+}
+
+.md-typeset table th[role=columnheader]:after {
+    content: "";
+    display: inline-block;
+    height: 1.2em;
+    margin-left: .5em;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m18 21-4-4h3V7h-3l4-4 4 4h-3v10h3M2 19v-2h10v2M2 13v-2h7v2M2 7V5h4v2H2z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m18 21-4-4h3V7h-3l4-4 4 4h-3v10h3M2 19v-2h10v2M2 13v-2h7v2M2 7V5h4v2H2z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    transition: background-color 125ms;
+    vertical-align: text-bottom;
+    width: 1.2em
+}
+
+.md-typeset table th[role=columnheader]:hover:after {
+    background-color: rgba(0,0,0,0.32)
+}
+
+.md-typeset table th[role=columnheader][aria-sort=ascending]:after {
+    background-color: rgba(0,0,0,0.54);
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 17h3l-4 4-4-4h3V3h2M2 17h10v2H2M6 5v2H2V5m0 6h7v2H2v-2z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 17h3l-4 4-4-4h3V3h2M2 17h10v2H2M6 5v2H2V5m0 6h7v2H2v-2z"/></svg>');
+}
+
+.md-typeset table th[role=columnheader][aria-sort=descending]:after {
+    background-color: rgba(0,0,0,0.54);
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 7h3l-4-4-4 4h3v14h2M2 17h10v2H2M6 5v2H2V5m0 6h7v2H2v-2z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 7h3l-4-4-4 4h3v14h2M2 17h10v2H2M6 5v2H2V5m0 6h7v2H2v-2z"/></svg>');
+}
+
+.md-typeset__scrollwrap {
+    margin: 1em -.8rem;
+    overflow-x: auto;
+    touch-action: auto
+}
+
+.md-typeset__table {
+    display: inline-block;
+    margin-bottom: .5em;
+    padding: 0 .8rem
+}
+
+@media print {
+    .md-typeset__table {
+        display: block
+    }
+}
+
+html .md-typeset__table table {
+    display: table;
+    margin: 0;
+    overflow: hidden;
+    width: 100%
+}
+
+html {
+    font-size: 125%;
+    height: 100%;
+    overflow-x: hidden
+}
+
+@media screen and (min-width: 100em) {
+    html {
+        font-size:137.5%
+    }
+}
+
+@media screen and (min-width: 125em) {
+    html {
+        font-size:150%
+    }
+}
+
+body {
+    background-color: #fff;
+    display: flex;
+    flex-direction: column;
+    font-size: .5rem;
+    min-height: 100%;
+    position: relative;
+    width: 100%
+}
+
+@media print {
+    body {
+        display: block
+    }
+}
+
+@media screen and (max-width: 59.9375em) {
+    body[data-md-state=lock] {
+        position:fixed
+    }
+}
+
+.md-grid {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 61rem
+}
+
+.md-container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1
+}
+
+@media print {
+    .md-container {
+        display: block
+    }
+}
+
+.md-main {
+    flex-grow: 1
+}
+
+.md-main__inner {
+    display: flex;
+    height: 100%;
+    margin-top: 1.5rem
+}
+
+.md-ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap
+}
+
+.md-toggle {
+    display: none
+}
+
+.md-option {
+    height: 0;
+    opacity: 0;
+    position: absolute;
+    width: 0
+}
+
+.md-option:checked+label:not([hidden]) {
+    display: block
+}
+
+.md-option.focus-visible+label {
+    outline-color: #526cfe;
+    outline-style: auto
+}
+
+.md-skip {
+    background-color: rgba(0,0,0,0.87);
+    border-radius: .1rem;
+    color: #fff;
+    font-size: .64rem;
+    margin: .5rem;
+    opacity: 0;
+    outline-color: #526cfe;
+    padding: .3rem .5rem;
+    position: fixed;
+    transform: translateY(.4rem);
+    z-index: -1
+}
+
+.md-skip:focus {
+    opacity: 1;
+    transform: translateY(0);
+    transition: transform .25s cubic-bezier(.4,0,.2,1),opacity 175ms 75ms;
+    z-index: 10
+}
+
+@page {
+    margin: 25mm
+}
+
+.md-announce {
+    background-color: rgba(0,0,0,0.87);
+    overflow: auto
+}
+
+@media print {
+    .md-announce {
+        display: none
+    }
+}
+
+.md-announce__inner {
+    color: #fff;
+    font-size: .7rem;
+    margin: .6rem auto;
+    padding: 0 .8rem
+}
+
+.md-clipboard {
+    border-radius: .1rem;
+    color: rgba(0,0,0,0.07);
+    cursor: pointer;
+    height: 1.5em;
+    outline-color: #526cfe;
+    outline-offset: .1rem;
+    position: absolute;
+    right: .5em;
+    top: .5em;
+    transition: color .25s;
+    width: 1.5em;
+    z-index: 1
+}
+
+@media print {
+    .md-clipboard {
+        display: none
+    }
+}
+
+.md-clipboard:not(.focus-visible) {
+    -webkit-tap-highlight-color: transparent;
+    outline: none
+}
+
+:hover>.md-clipboard {
+    color: rgba(0,0,0,0.54)
+}
+
+.md-clipboard:focus,.md-clipboard:hover {
+    color: #526cfe
+}
+
+.md-clipboard:after {
+    background-color: currentColor;
+    content: "";
+    display: block;
+    height: 1.125em;
+    margin: 0 auto;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 21H8V7h11m0-2H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2m-3-4H4a2 2 0 0 0-2 2v14h2V3h12V1z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 21H8V7h11m0-2H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2m-3-4H4a2 2 0 0 0-2 2v14h2V3h12V1z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    width: 1.125em
+}
+
+.md-clipboard--inline {
+    cursor: pointer
+}
+
+.md-clipboard--inline code {
+    transition: color .25s,background-color .25s
+}
+
+.md-clipboard--inline:focus code,.md-clipboard--inline:hover code {
+    background-color: rgba(82,108,254,0.1);
+    color: #526cfe
+}
+
+.md-content {
+    flex-grow: 1;
+    overflow: hidden;
+    scroll-padding-top: 51.2rem
+}
+
+.md-content__inner {
+    margin: 0 .8rem 1.2rem;
+    padding-top: .6rem
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-sidebar--primary:not([hidden])~.md-content>.md-content__inner {
+        margin-left:1.2rem
+    }
+
+    [dir=rtl] .md-sidebar--primary:not([hidden])~.md-content>.md-content__inner {
+        margin-left: .8rem;
+        margin-right: 1.2rem
+    }
+
+    .md-sidebar--secondary:not([hidden])~.md-content>.md-content__inner {
+        margin-right: 1.2rem
+    }
+
+    [dir=rtl] .md-sidebar--secondary:not([hidden])~.md-content>.md-content__inner {
+        margin-left: 1.2rem;
+        margin-right: .8rem
+    }
+}
+
+.md-content__inner:before {
+    content: "";
+    display: block;
+    height: .4rem
+}
+
+.md-content__inner>:last-child {
+    margin-bottom: 0
+}
+
+.md-content__button {
+    float: right;
+    margin: .4rem 0 .4rem .4rem;
+    padding: 0
+}
+
+@media print {
+    .md-content__button {
+        display: none
+    }
+}
+
+[dir=rtl] .md-content__button {
+    float: left;
+    margin-left: 0;
+    margin-right: .4rem
+}
+
+[dir=rtl] .md-content__button svg {
+    transform: scaleX(-1)
+}
+
+.md-typeset .md-content__button {
+    color: rgba(0,0,0,0.32)
+}
+
+.md-content__button svg {
+    display: inline;
+    vertical-align: top
+}
+
+.md-dialog {
+    background-color: rgba(0,0,0,0.87);
+    border-radius: .1rem;
+    bottom: .8rem;
+    box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12),0 3px 1px -2px rgba(0,0,0,.2);
+    left: auto;
+    min-width: 11.1rem;
+    opacity: 0;
+    padding: .4rem .6rem;
+    pointer-events: none;
+    position: fixed;
+    right: .8rem;
+    transform: translateY(100%);
+    transition: transform 0ms .4s,opacity .4s;
+    z-index: 3
+}
+
+@media print {
+    .md-dialog {
+        display: none
+    }
+}
+
+[dir=rtl] .md-dialog {
+    left: .8rem;
+    right: auto
+}
+
+.md-dialog[data-md-state=open] {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+    transition: transform .4s cubic-bezier(.075,.85,.175,1),opacity .4s
+}
+
+.md-dialog__inner {
+    color: #fff;
+    font-size: .7rem
+}
+
+.md-typeset .md-button {
+    border: .1rem solid;
+    border-radius: .1rem;
+    color: #ef5552;
+    cursor: pointer;
+    display: inline-block;
+    font-weight: 700;
+    padding: .625em 2em;
+    transition: color 125ms,background-color 125ms,border-color 125ms
+}
+
+.md-typeset .md-button--primary {
+    background-color: #ef5552;
+    border-color: #ef5552;
+    color: #fff;
+}
+
+.md-typeset .md-button:focus,.md-typeset .md-button:hover {
+    background-color: #526cfe;
+    border-color: #526cfe;
+    color: #fff;
+}
+
+.md-typeset .md-input {
+    border-radius: .1rem;
+    box-shadow: 0 .2rem .5rem rgba(0,0,0,.1),0 .025rem .05rem rgba(0,0,0,.1);
+    font-size: .8rem;
+    height: 1.8rem;
+    padding: 0 .6rem;
+    transition: box-shadow .25s
+}
+
+.md-typeset .md-input:focus,.md-typeset .md-input:hover {
+    box-shadow: 0 .4rem 1rem rgba(0,0,0,.15),0 .025rem .05rem rgba(0,0,0,.15)
+}
+
+.md-typeset .md-input--stretch {
+    width: 100%
+}
+
+.md-header {
+    background-color: #ef5552;
+    box-shadow: 0 0 .2rem transparent,0 .2rem .4rem transparent;
+    color: #fff;
+    left: 0;
+    position: -webkit-sticky;
+    position: sticky;
+    right: 0;
+    top: 0;
+    z-index: 3
+}
+
+@media print {
+    .md-header {
+        display: none
+    }
+}
+
+.md-header[data-md-state=shadow] {
+    box-shadow: 0 0 .2rem rgba(0,0,0,.1),0 .2rem .4rem rgba(0,0,0,.2);
+    transition: transform .25s cubic-bezier(.1,.7,.1,1),box-shadow .25s
+}
+
+.md-header[data-md-state=hidden] {
+    transform: translateY(-100%);
+    transition: transform .25s cubic-bezier(.8,0,.6,1),box-shadow .25s
+}
+
+.md-header__inner {
+    align-items: center;
+    display: flex;
+    padding: 0 .2rem
+}
+
+.md-header__button {
+    color: currentColor;
+    cursor: pointer;
+    margin: .2rem;
+    outline-color: #526cfe;
+    padding: .4rem;
+    position: relative;
+    transition: opacity .25s;
+    vertical-align: middle;
+    z-index: 1
+}
+
+.md-header__button:hover {
+    opacity: .7
+}
+
+.md-header__button:not([hidden]) {
+    display: inline-block
+}
+
+.md-header__button:not(.focus-visible) {
+    -webkit-tap-highlight-color: transparent;
+    outline: none
+}
+
+.md-header__button.md-logo {
+    margin: .2rem;
+    padding: .4rem
+}
+
+@media screen and (max-width: 76.1875em) {
+    .md-header__button.md-logo {
+        display:none
+    }
+}
+
+.md-header__button.md-logo img,.md-header__button.md-logo svg {
+    fill: currentColor;
+    display: block;
+    height: 1.2rem;
+    width: 1.2rem
+}
+
+@media screen and (min-width: 60em) {
+    .md-header__button[for=__search] {
+        display:none
+    }
+}
+
+.no-js .md-header__button[for=__search] {
+    display: none
+}
+
+[dir=rtl] .md-header__button[for=__search] svg {
+    transform: scaleX(-1)
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-header__button[for=__drawer] {
+        display:none
+    }
+}
+
+.md-header__topic {
+    display: flex;
+    max-width: 100%;
+    position: absolute;
+    transition: transform .4s cubic-bezier(.1,.7,.1,1),opacity .15s
+}
+
+.md-header__topic+.md-header__topic {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateX(1.25rem);
+    transition: transform .4s cubic-bezier(1,.7,.1,.1),opacity .15s;
+    z-index: -1
+}
+
+[dir=rtl] .md-header__topic+.md-header__topic {
+    transform: translateX(-1.25rem)
+}
+
+.md-header__title {
+    flex-grow: 1;
+    font-size: .9rem;
+    height: 2.4rem;
+    line-height: 2.4rem;
+    margin-left: 1rem;
+    margin-right: .4rem
+}
+
+.md-header__title[data-md-state=active] .md-header__topic {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateX(-1.25rem);
+    transition: transform .4s cubic-bezier(1,.7,.1,.1),opacity .15s;
+    z-index: -1
+}
+
+[dir=rtl] .md-header__title[data-md-state=active] .md-header__topic {
+    transform: translateX(1.25rem)
+}
+
+.md-header__title[data-md-state=active] .md-header__topic+.md-header__topic {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(0);
+    transition: transform .4s cubic-bezier(.1,.7,.1,1),opacity .15s;
+    z-index: 0
+}
+
+.md-header__title>.md-header__ellipsis {
+    height: 100%;
+    position: relative;
+    width: 100%
+}
+
+.md-header__option {
+    display: flex;
+    flex-shrink: 0;
+    max-width: 100%;
+    transition: max-width 0ms .25s,opacity .25s .25s;
+    white-space: nowrap
+}
+
+[data-md-toggle=search]:checked~.md-header .md-header__option {
+    max-width: 0;
+    opacity: 0;
+    transition: max-width 0ms,opacity 0ms
+}
+
+.md-header__source {
+    display: none
+}
+
+@media screen and (min-width: 60em) {
+    .md-header__source {
+        display:block;
+        margin-left: 1rem;
+        max-width: 11.7rem;
+        width: 11.7rem
+    }
+
+    [dir=rtl] .md-header__source {
+        margin-left: 0;
+        margin-right: 1rem
+    }
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-header__source {
+        margin-left:1.4rem
+    }
+
+    [dir=rtl] .md-header__source {
+        margin-right: 1.4rem
+    }
+}
+
+.md-footer {
+    background-color: rgba(0,0,0,0.87);
+    color: #fff
+}
+
+@media print {
+    .md-footer {
+        display: none
+    }
+}
+
+.md-footer__inner {
+    overflow: auto;
+    padding: .2rem
+}
+
+.md-footer__link {
+    display: flex;
+    outline-color: #526cfe;
+    padding-bottom: .4rem;
+    padding-top: 1.4rem;
+    transition: opacity .25s
+}
+
+@media screen and (min-width: 45em) {
+    .md-footer__link {
+        width:50%
+    }
+}
+
+.md-footer__link:focus,.md-footer__link:hover {
+    opacity: .7
+}
+
+.md-footer__link--prev {
+    float: left
+}
+
+@media screen and (max-width: 44.9375em) {
+    .md-footer__link--prev {
+        width:25%
+    }
+
+    .md-footer__link--prev .md-footer__title {
+        display: none
+    }
+}
+
+[dir=rtl] .md-footer__link--prev {
+    float: right
+}
+
+[dir=rtl] .md-footer__link--prev svg {
+    transform: scaleX(-1)
+}
+
+.md-footer__link--next {
+    float: right;
+    text-align: right
+}
+
+@media screen and (max-width: 44.9375em) {
+    .md-footer__link--next {
+        width:75%
+    }
+}
+
+[dir=rtl] .md-footer__link--next {
+    float: left;
+    text-align: left
+}
+
+[dir=rtl] .md-footer__link--next svg {
+    transform: scaleX(-1)
+}
+
+.md-footer__title {
+    flex-grow: 1;
+    font-size: .9rem;
+    line-height: 2.4rem;
+    max-width: calc(100% - 2.4rem);
+    padding: 0 1rem;
+    position: relative
+}
+
+.md-footer__button {
+    margin: .2rem;
+    padding: .4rem
+}
+
+.md-footer__direction {
+    font-size: .64rem;
+    left: 0;
+    margin-top: -1rem;
+    opacity: .7;
+    padding: 0 1rem;
+    position: absolute;
+    right: 0
+}
+
+.md-footer-meta {
+    background-color: rgba(0,0,0,0.32);
+}
+
+.md-footer-meta__inner {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    padding: .2rem
+}
+
+html .md-footer-meta.md-typeset a {
+    color: hsla(0,0%,100%,0.7)
+}
+
+html .md-footer-meta.md-typeset a:focus,html .md-footer-meta.md-typeset a:hover {
+    color: #fff
+}
+
+.md-footer-copyright {
+    color: hsla(0,0%,100%,0.3);
+    font-size: .64rem;
+    margin: auto .6rem;
+    padding: .4rem 0;
+    width: 100%
+}
+
+@media screen and (min-width: 45em) {
+    .md-footer-copyright {
+        width:auto
+    }
+}
+
+.md-footer-copyright__highlight {
+    color: hsla(0,0%,100%,0.7);
+}
+
+.md-footer-social {
+    margin: 0 .4rem;
+    padding: .2rem 0 .6rem
+}
+
+@media screen and (min-width: 45em) {
+    .md-footer-social {
+        padding:.6rem 0
+    }
+}
+
+.md-footer-social__link {
+    display: inline-block;
+    height: 1.6rem;
+    text-align: center;
+    width: 1.6rem
+}
+
+.md-footer-social__link:before {
+    line-height: 1.9
+}
+
+.md-footer-social__link svg {
+    fill: currentColor;
+    max-height: .8rem;
+    vertical-align: -25%
+}
+
+.md-nav {
+    font-size: .7rem;
+    line-height: 1.3
+}
+
+.md-nav__title {
+    display: block;
+    font-weight: 700;
+    overflow: hidden;
+    padding: 0 .6rem;
+    text-overflow: ellipsis
+}
+
+.md-nav__title .md-nav__button {
+    display: none
+}
+
+.md-nav__title .md-nav__button img {
+    height: 100%;
+    width: auto
+}
+
+.md-nav__title .md-nav__button.md-logo img,.md-nav__title .md-nav__button.md-logo svg {
+    fill: currentColor;
+    display: block;
+    height: 2.4rem;
+    width: 2.4rem
+}
+
+.md-nav__list {
+    list-style: none;
+    margin: 0;
+    padding: 0
+}
+
+.md-nav__item {
+    padding: 0 .6rem
+}
+
+.md-nav__item .md-nav__item {
+    padding-right: 0
+}
+
+[dir=rtl] .md-nav__item .md-nav__item {
+    padding-left: 0;
+    padding-right: .6rem
+}
+
+.md-nav__link {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    margin-top: .625em;
+    overflow: hidden;
+    scroll-snap-align: start;
+    text-overflow: ellipsis;
+    transition: color 125ms
+}
+
+.md-nav__link[data-md-state=blur] {
+    color: rgba(0,0,0,0.54)
+}
+
+.md-nav__item .md-nav__link--active {
+    color: #ef5552;
+}
+
+.md-nav__item .md-nav__link--index [href] {
+    width: 100%
+}
+
+.md-nav__link:focus,.md-nav__link:hover {
+    color: #526cfe;
+}
+
+.md-nav__link.focus-visible {
+    outline-color: #526cfe;
+    outline-offset: .2rem
+}
+
+.md-nav--primary .md-nav__link[for=__toc] {
+    display: none
+}
+
+.md-nav--primary .md-nav__link[for=__toc] .md-icon:after {
+    background-color: currentColor;
+    display: block;
+    height: 100%;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 9h14V7H3v2m0 4h14v-2H3v2m0 4h14v-2H3v2m16 0h2v-2h-2v2m0-10v2h2V7h-2m0 6h2v-2h-2v2z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 9h14V7H3v2m0 4h14v-2H3v2m0 4h14v-2H3v2m16 0h2v-2h-2v2m0-10v2h2V7h-2m0 6h2v-2h-2v2z"/></svg>');
+    width: 100%
+}
+
+.md-nav--primary .md-nav__link[for=__toc]~.md-nav {
+    display: none
+}
+
+.md-nav__link>* {
+    cursor: pointer;
+    display: flex
+}
+
+.md-nav__source {
+    display: none
+}
+
+@media screen and (max-width: 76.1875em) {
+    .md-nav--primary,.md-nav--primary .md-nav {
+        background-color:#fff;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+        z-index: 1
+    }
+
+    .md-nav--primary .md-nav__item,.md-nav--primary .md-nav__title {
+        font-size: .8rem;
+        line-height: 1.5
+    }
+
+    .md-nav--primary .md-nav__title {
+        background-color: rgba(0,0,0,0.07);
+        color: rgba(0,0,0,0.54);
+        cursor: pointer;
+        font-weight: 400;
+        height: 5.6rem;
+        line-height: 2.4rem;
+        padding: 3rem .8rem .2rem;
+        position: relative;
+        white-space: nowrap
+    }
+
+    .md-nav--primary .md-nav__title .md-nav__icon {
+        display: block;
+        height: 1.2rem;
+        left: .4rem;
+        margin: .2rem;
+        position: absolute;
+        top: .4rem;
+        width: 1.2rem
+    }
+
+    [dir=rtl] .md-nav--primary .md-nav__title .md-nav__icon {
+        left: auto;
+        right: .4rem
+    }
+
+    .md-nav--primary .md-nav__title .md-nav__icon:after {
+        background-color: currentColor;
+        content: "";
+        display: block;
+        height: 100%;
+        -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 11v2H8l5.5 5.5-1.42 1.42L4.16 12l7.92-7.92L13.5 5.5 8 11h12z"/></svg>');
+        mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 11v2H8l5.5 5.5-1.42 1.42L4.16 12l7.92-7.92L13.5 5.5 8 11h12z"/></svg>');
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        width: 100%
+    }
+
+    .md-nav--primary .md-nav__title~.md-nav__list {
+        background-color: #fff;
+        box-shadow: 0 .05rem 0 rgba(0,0,0,0.07) inset;
+        overflow-y: auto;
+        -ms-scroll-snap-type: y mandatory;
+        scroll-snap-type: y mandatory;
+        touch-action: pan-y
+    }
+
+    .md-nav--primary .md-nav__title~.md-nav__list>:first-child {
+        border-top: 0
+    }
+
+    .md-nav--primary .md-nav__title[for=__drawer] {
+        background-color: #ef5552;
+        color: #fff
+    }
+
+    .md-nav--primary .md-nav__title .md-logo {
+        display: block;
+        left: .2rem;
+        margin: .2rem;
+        padding: .4rem;
+        position: absolute;
+        top: .2rem
+    }
+
+    [dir=rtl] .md-nav--primary .md-nav__title .md-logo {
+        left: auto;
+        right: .2rem
+    }
+
+    .md-nav--primary .md-nav__list {
+        flex: 1
+    }
+
+    .md-nav--primary .md-nav__item {
+        border-top: .05rem solid rgba(0,0,0,0.07);
+        padding: 0
+    }
+
+    .md-nav--primary .md-nav__item--active>.md-nav__link {
+        color: #ef5552
+    }
+
+    .md-nav--primary .md-nav__item--active>.md-nav__link:focus,.md-nav--primary .md-nav__item--active>.md-nav__link:hover {
+        color: #526cfe
+    }
+
+    .md-nav--primary .md-nav__link {
+        margin-top: 0;
+        padding: .6rem .8rem
+    }
+
+    .md-nav--primary .md-nav__link .md-nav__icon {
+        flex-shrink: 0;
+        font-size: 1.2rem;
+        height: 1.2rem;
+        margin-right: -.2rem;
+        width: 1.2rem
+    }
+
+    [dir=rtl] .md-nav--primary .md-nav__link .md-nav__icon {
+        margin-left: -.2rem;
+        margin-right: 0
+    }
+
+    .md-nav--primary .md-nav__link .md-nav__icon:after {
+        background-color: currentColor;
+        content: "";
+        display: block;
+        height: 100%;
+        -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z"/></svg>');
+        mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z"/></svg>');
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        width: 100%
+    }
+
+    [dir=rtl] .md-nav--primary .md-nav__icon:after {
+        transform: scale(-1)
+    }
+
+    .md-nav--primary .md-nav--secondary .md-nav {
+        background-color: transparent;
+        position: static
+    }
+
+    .md-nav--primary .md-nav--secondary .md-nav .md-nav__link {
+        padding-left: 1.4rem
+    }
+
+    [dir=rtl] .md-nav--primary .md-nav--secondary .md-nav .md-nav__link {
+        padding-left: 0;
+        padding-right: 1.4rem
+    }
+
+    .md-nav--primary .md-nav--secondary .md-nav .md-nav .md-nav__link {
+        padding-left: 2rem
+    }
+
+    [dir=rtl] .md-nav--primary .md-nav--secondary .md-nav .md-nav .md-nav__link {
+        padding-left: 0;
+        padding-right: 2rem
+    }
+
+    .md-nav--primary .md-nav--secondary .md-nav .md-nav .md-nav .md-nav__link {
+        padding-left: 2.6rem
+    }
+
+    [dir=rtl] .md-nav--primary .md-nav--secondary .md-nav .md-nav .md-nav .md-nav__link {
+        padding-left: 0;
+        padding-right: 2.6rem
+    }
+
+    .md-nav--primary .md-nav--secondary .md-nav .md-nav .md-nav .md-nav .md-nav__link {
+        padding-left: 3.2rem
+    }
+
+    [dir=rtl] .md-nav--primary .md-nav--secondary .md-nav .md-nav .md-nav .md-nav .md-nav__link {
+        padding-left: 0;
+        padding-right: 3.2rem
+    }
+
+    .md-nav--secondary {
+        background-color: transparent
+    }
+
+    .md-nav__toggle~.md-nav {
+        display: flex;
+        opacity: 0;
+        transform: translateX(100%);
+        transition: transform .25s cubic-bezier(.8,0,.6,1),opacity 125ms 50ms
+    }
+
+    [dir=rtl] .md-nav__toggle~.md-nav {
+        transform: translateX(-100%)
+    }
+
+    .md-nav__toggle:checked~.md-nav {
+        opacity: 1;
+        transform: translateX(0);
+        transition: transform .25s cubic-bezier(.4,0,.2,1),opacity 125ms 125ms
+    }
+
+    .md-nav__toggle:checked~.md-nav>.md-nav__list {
+        -webkit-backface-visibility: hidden;
+        backface-visibility: hidden
+    }
+}
+
+@media screen and (max-width: 59.9375em) {
+    .md-nav--primary .md-nav__link[for=__toc] {
+        display:flex
+    }
+
+    .md-nav--primary .md-nav__link[for=__toc] .md-icon:after {
+        content: ""
+    }
+
+    .md-nav--primary .md-nav__link[for=__toc]+.md-nav__link {
+        display: none
+    }
+
+    .md-nav--primary .md-nav__link[for=__toc]~.md-nav {
+        display: flex
+    }
+
+    .md-nav__source {
+        background-color: #e53734;
+        color: #fff;
+        display: block;
+        padding: 0 .2rem
+    }
+}
+
+@media screen and (min-width: 60em) and (max-width:76.1875em) {
+    .md-nav--integrated .md-nav__link[for=__toc] {
+        display:flex
+    }
+
+    .md-nav--integrated .md-nav__link[for=__toc] .md-icon:after {
+        content: ""
+    }
+
+    .md-nav--integrated .md-nav__link[for=__toc]+.md-nav__link {
+        display: none
+    }
+
+    .md-nav--integrated .md-nav__link[for=__toc]~.md-nav {
+        display: flex
+    }
+}
+
+@media screen and (min-width: 60em) {
+    .md-nav--secondary .md-nav__title[for=__toc] {
+        scroll-snap-align:start
+    }
+
+    .md-nav--secondary .md-nav__title .md-nav__icon {
+        display: none
+    }
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-nav {
+        transition:max-height .25s cubic-bezier(.86,0,.07,1)
+    }
+
+    .md-nav--primary .md-nav__title[for=__drawer] {
+        scroll-snap-align: start
+    }
+
+    .md-nav--primary .md-nav__title .md-nav__icon {
+        display: none
+    }
+
+    .md-nav__toggle~.md-nav {
+        display: none
+    }
+
+    .md-nav__toggle:checked~.md-nav,.md-nav__toggle:indeterminate~.md-nav {
+        display: block
+    }
+
+    .md-nav__item--nested>.md-nav>.md-nav__title {
+        display: none
+    }
+
+    .md-nav__item--section {
+        display: block;
+        margin: 1.25em 0
+    }
+
+    .md-nav__item--section:last-child {
+        margin-bottom: 0
+    }
+
+    .md-nav__item--section>.md-nav__link {
+        font-weight: 700;
+        pointer-events: none
+    }
+
+    .md-nav__item--section>.md-nav__link--index [href] {
+        pointer-events: auto
+    }
+
+    .md-nav__item--section>.md-nav__link .md-nav__icon {
+        display: none
+    }
+
+    .md-nav__item--section>.md-nav {
+        display: block
+    }
+
+    .md-nav__item--section>.md-nav>.md-nav__list>.md-nav__item {
+        padding: 0
+    }
+
+    .md-nav__icon {
+        float: right;
+        height: .9rem;
+        transition: transform .25s;
+        width: .9rem
+    }
+
+    [dir=rtl] .md-nav__icon {
+        float: left;
+        transform: rotate(180deg)
+    }
+
+    .md-nav__icon:after {
+        background-color: currentColor;
+        content: "";
+        display: inline-block;
+        height: 100%;
+        -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z"/></svg>');;
+        mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z"/></svg>');;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        vertical-align: -.1rem;
+        width: 100%
+    }
+
+    .md-nav__item--nested .md-nav__toggle:checked~.md-nav__link .md-nav__icon,.md-nav__item--nested .md-nav__toggle:indeterminate~.md-nav__link .md-nav__icon {
+        transform: rotate(90deg)
+    }
+
+    .md-nav--lifted>.md-nav__list>.md-nav__item--nested,.md-nav--lifted>.md-nav__title {
+        display: none
+    }
+
+    .md-nav--lifted>.md-nav__list>.md-nav__item {
+        display: none
+    }
+
+    .md-nav--lifted>.md-nav__list>.md-nav__item--active {
+        display: block;
+        padding: 0
+    }
+
+    .md-nav--lifted>.md-nav__list>.md-nav__item--active>.md-nav__link {
+        font-weight: 700;
+        padding: 0 .6rem;
+        pointer-events: none
+    }
+
+    .md-nav--lifted>.md-nav__list>.md-nav__item--active>.md-nav__link--index [href] {
+        pointer-events: auto
+    }
+
+    .md-nav--lifted>.md-nav__list>.md-nav__item--active>.md-nav__link .md-nav__icon {
+        display: none
+    }
+
+    .md-nav--lifted .md-nav[data-md-level="1"] {
+        display: block
+    }
+
+    .md-nav--lifted .md-nav[data-md-level="1"]>.md-nav__list>.md-nav__item {
+        padding-right: .6rem
+    }
+
+    .md-nav--integrated .md-nav__link[for=__toc]~.md-nav {
+        border-left: .05rem solid #e53734;
+        display: block;
+        margin-bottom: 1.25em
+    }
+
+    .md-nav--integrated .md-nav__link[for=__toc]~.md-nav>.md-nav__title {
+        display: none
+    }
+}
+
+.md-search {
+    position: relative
+}
+
+@media screen and (min-width: 60em) {
+    .md-search {
+        padding:.2rem 0
+    }
+}
+
+.no-js .md-search {
+    display: none
+}
+
+.md-search__overlay {
+    opacity: 0;
+    z-index: 1
+}
+
+@media screen and (max-width: 59.9375em) {
+    .md-search__overlay {
+        background-color:#fff;
+        border-radius: 1rem;
+        height: 2rem;
+        left: -2.2rem;
+        overflow: hidden;
+        pointer-events: none;
+        position: absolute;
+        top: -1rem;
+        transform-origin: center;
+        transition: transform .3s .1s,opacity .2s .2s;
+        width: 2rem
+    }
+
+    [dir=rtl] .md-search__overlay {
+        left: auto;
+        right: -2.2rem
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__overlay {
+        opacity: 1;
+        transition: transform .4s,opacity .1s
+    }
+}
+
+@media screen and (min-width: 60em) {
+    .md-search__overlay {
+        background-color:rgba(0,0,0,.54);
+        cursor: pointer;
+        height: 0;
+        left: 0;
+        position: fixed;
+        top: 0;
+        transition: width 0ms .25s,height 0ms .25s,opacity .25s;
+        width: 0
+    }
+
+    [dir=rtl] .md-search__overlay {
+        left: auto;
+        right: 0
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__overlay {
+        height: 200vh;
+        opacity: 1;
+        transition: width 0ms,height 0ms,opacity .25s;
+        width: 100%
+    }
+}
+
+@media screen and (max-width: 29.9375em) {
+    [data-md-toggle=search]:checked~.md-header .md-search__overlay {
+        transform:scale(45)
+    }
+}
+
+@media screen and (min-width: 30em) and (max-width:44.9375em) {
+    [data-md-toggle=search]:checked~.md-header .md-search__overlay {
+        transform:scale(60)
+    }
+}
+
+@media screen and (min-width: 45em) and (max-width:59.9375em) {
+    [data-md-toggle=search]:checked~.md-header .md-search__overlay {
+        transform:scale(75)
+    }
+}
+
+.md-search__inner {
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden
+}
+
+@media screen and (max-width: 59.9375em) {
+    .md-search__inner {
+        height:0;
+        left: 0;
+        opacity: 0;
+        overflow: hidden;
+        position: fixed;
+        top: 0;
+        transform: translateX(5%);
+        transition: width 0ms .3s,height 0ms .3s,transform .15s cubic-bezier(.4,0,.2,1) .15s,opacity .15s .15s;
+        width: 0;
+        z-index: 2
+    }
+
+    [dir=rtl] .md-search__inner {
+        left: auto;
+        right: 0;
+        transform: translateX(-5%)
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__inner {
+        height: 100%;
+        opacity: 1;
+        transform: translateX(0);
+        transition: width 0ms 0ms,height 0ms 0ms,transform .15s cubic-bezier(.1,.7,.1,1) .15s,opacity .15s .15s;
+        width: 100%
+    }
+}
+
+@media screen and (min-width: 60em) {
+    .md-search__inner {
+        float:right;
+        padding: .1rem 0;
+        position: relative;
+        transition: width .25s cubic-bezier(.1,.7,.1,1);
+        width: 11.7rem
+    }
+
+    [dir=rtl] .md-search__inner {
+        float: left
+    }
+}
+
+@media screen and (min-width: 60em) and (max-width:76.1875em) {
+    [data-md-toggle=search]:checked~.md-header .md-search__inner {
+        width:23.4rem
+    }
+}
+
+@media screen and (min-width: 76.25em) {
+    [data-md-toggle=search]:checked~.md-header .md-search__inner {
+        width:34.4rem
+    }
+}
+
+.md-search__form {
+    background-color: #fff;
+    box-shadow: 0 0 .6rem transparent;
+    height: 2.4rem;
+    position: relative;
+    transition: color .25s,background-color .25s;
+    z-index: 2
+}
+
+@media screen and (min-width: 60em) {
+    .md-search__form {
+        background-color:rgba(0,0,0,.26);
+        border-radius: .1rem;
+        height: 1.8rem
+    }
+
+    .md-search__form:hover {
+        background-color: hsla(0,0%,100%,.12)
+    }
+}
+
+[data-md-toggle=search]:checked~.md-header .md-search__form {
+    background-color: #fff;
+    border-radius: .1rem .1rem 0 0;
+    box-shadow: 0 0 .6rem rgba(0,0,0,.07);
+    color: rgba(0,0,0,0.87)
+}
+
+.md-search__input {
+    background: transparent;
+    font-size: .9rem;
+    height: 100%;
+    padding: 0 2.2rem 0 3.6rem;
+    position: relative;
+    text-overflow: ellipsis;
+    width: 100%;
+    z-index: 2
+}
+
+[dir=rtl] .md-search__input {
+    padding: 0 3.6rem 0 2.2rem
+}
+
+.md-search__input::-webkit-input-placeholder {
+    -webkit-transition: color .25s;
+    transition: color .25s
+}
+
+.md-search__input::-moz-placeholder {
+    -moz-transition: color .25s;
+    transition: color .25s
+}
+
+.md-search__input::-ms-input-placeholder {
+    -ms-transition: color .25s;
+    transition: color .25s
+}
+
+.md-search__input::placeholder {
+    transition: color .25s
+}
+
+.md-search__input::-webkit-input-placeholder {
+    color: rgba(0,0,0,0.54)
+}
+
+.md-search__input::-moz-placeholder {
+    color: rgba(0,0,0,0.54)
+}
+
+.md-search__input::-ms-input-placeholder {
+    color: rgba(0,0,0,0.54)
+}
+
+.md-search__input::placeholder,.md-search__input~.md-search__icon {
+    color: rgba(0,0,0,0.54)
+}
+
+.md-search__input::-ms-clear {
+    display: none
+}
+
+@media screen and (max-width: 59.9375em) {
+    .md-search__input {
+        font-size:.9rem;
+        height: 2.4rem;
+        width: 100%
+    }
+}
+
+@media screen and (min-width: 60em) {
+    .md-search__input {
+        color:inherit;
+        font-size: .8rem;
+        padding-left: 2.2rem
+    }
+
+    [dir=rtl] .md-search__input {
+        padding-right: 2.2rem
+    }
+
+    .md-search__input::-webkit-input-placeholder {
+        color: hsla(0,0%,100%,0.7);
+    }
+
+    .md-search__input::-moz-placeholder {
+        color: hsla(0,0%,100%,0.7);
+    }
+
+    .md-search__input::-ms-input-placeholder {
+        color: hsla(0,0%,100%,0.7);
+    }
+
+    .md-search__input::placeholder {
+        color: hsla(0,0%,100%,0.7);
+    }
+
+    .md-search__input+.md-search__icon {
+        color: #fff
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__input {
+        text-overflow: clip
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__input::-webkit-input-placeholder {
+        color: rgba(0,0,0,0.54)
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__input::-moz-placeholder {
+        color: rgba(0,0,0,0.54)
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__input::-ms-input-placeholder {
+        color: rgba(0,0,0,0.54)
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__input+.md-search__icon,[data-md-toggle=search]:checked~.md-header .md-search__input::placeholder {
+        color: rgba(0,0,0,0.54)
+    }
+}
+
+.md-search__icon {
+    cursor: pointer;
+    display: inline-block;
+    height: 1.2rem;
+    transition: color .25s,opacity .25s;
+    width: 1.2rem
+}
+
+.md-search__icon:hover {
+    opacity: .7
+}
+
+.md-search__icon[for=__search] {
+    left: .5rem;
+    position: absolute;
+    top: .3rem;
+    z-index: 2
+}
+
+[dir=rtl] .md-search__icon[for=__search] {
+    left: auto;
+    right: .5rem
+}
+
+[dir=rtl] .md-search__icon[for=__search] svg {
+    transform: scaleX(-1)
+}
+
+@media screen and (max-width: 59.9375em) {
+    .md-search__icon[for=__search] {
+        left:.8rem;
+        top: .6rem
+    }
+
+    [dir=rtl] .md-search__icon[for=__search] {
+        left: auto;
+        right: .8rem
+    }
+
+    .md-search__icon[for=__search] svg:first-child {
+        display: none
+    }
+}
+
+@media screen and (min-width: 60em) {
+    .md-search__icon[for=__search] {
+        pointer-events:none
+    }
+
+    .md-search__icon[for=__search] svg:last-child {
+        display: none
+    }
+}
+
+.md-search__options {
+    pointer-events: none;
+    position: absolute;
+    right: .5rem;
+    top: .3rem;
+    z-index: 2
+}
+
+[dir=rtl] .md-search__options {
+    left: .5rem;
+    right: auto
+}
+
+@media screen and (max-width: 59.9375em) {
+    .md-search__options {
+        right:.8rem;
+        top: .6rem
+    }
+
+    [dir=rtl] .md-search__options {
+        left: .8rem;
+        right: auto
+    }
+}
+
+.md-search__options>* {
+    color: rgba(0,0,0,0.54);
+    margin-left: .2rem;
+    opacity: 0;
+    transform: scale(.75);
+    transition: transform .15s cubic-bezier(.1,.7,.1,1),opacity .15s
+}
+
+.md-search__options>:not(.focus-visible) {
+    -webkit-tap-highlight-color: transparent;
+    outline: none
+}
+
+[data-md-toggle=search]:checked~.md-header .md-search__input:valid~.md-search__options>* {
+    opacity: 1;
+    pointer-events: auto;
+    transform: scale(1)
+}
+
+[data-md-toggle=search]:checked~.md-header .md-search__input:valid~.md-search__options>:hover {
+    opacity: .7
+}
+
+.md-search__suggest {
+    align-items: center;
+    color: rgba(0,0,0,0.32);
+    display: flex;
+    font-size: .9rem;
+    height: 100%;
+    opacity: 0;
+    padding: 0 2.2rem 0 3.6rem;
+    position: absolute;
+    top: 0;
+    transition: opacity 50ms;
+    white-space: nowrap;
+    width: 100%
+}
+
+[dir=rtl] .md-search__suggest {
+    padding: 0 3.6rem 0 2.2rem
+}
+
+@media screen and (min-width: 60em) {
+    .md-search__suggest {
+        font-size:.8rem;
+        padding-left: 2.2rem
+    }
+
+    [dir=rtl] .md-search__suggest {
+        padding-right: 2.2rem
+    }
+}
+
+[data-md-toggle=search]:checked~.md-header .md-search__suggest {
+    opacity: 1;
+    transition: opacity .3s .1s
+}
+
+.md-search__output {
+    border-radius: 0 0 .1rem .1rem;
+    overflow: hidden;
+    position: absolute;
+    width: 100%;
+    z-index: 1
+}
+
+@media screen and (max-width: 59.9375em) {
+    .md-search__output {
+        bottom:0;
+        top: 2.4rem
+    }
+}
+
+@media screen and (min-width: 60em) {
+    .md-search__output {
+        opacity:0;
+        top: 1.9rem;
+        transition: opacity .4s
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__output {
+        box-shadow: 0 6px 10px 0 rgba(0,0,0,.14),0 1px 18px 0 rgba(0,0,0,.12),0 3px 5px -1px rgba(0,0,0,.4);
+        opacity: 1
+    }
+}
+
+.md-search__scrollwrap {
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    background-color: #fff;
+    height: 100%;
+    overflow-y: auto;
+    touch-action: pan-y
+}
+
+@media (-webkit-max-device-pixel-ratio: 1),(max-resolution:1dppx) {
+    .md-search__scrollwrap {
+        transform:translateZ(0)
+    }
+}
+
+@media screen and (min-width: 60em) and (max-width:76.1875em) {
+    .md-search__scrollwrap {
+        width:23.4rem
+    }
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-search__scrollwrap {
+        width:34.4rem
+    }
+}
+
+@media screen and (min-width: 60em) {
+    .md-search__scrollwrap {
+        max-height:0;
+        scrollbar-color: rgba(0,0,0,0.32) transparent;
+        scrollbar-width: thin
+    }
+
+    [data-md-toggle=search]:checked~.md-header .md-search__scrollwrap {
+        max-height: 75vh
+    }
+
+    .md-search__scrollwrap:hover {
+        scrollbar-color: #526cfe transparent
+    }
+
+    .md-search__scrollwrap::-webkit-scrollbar {
+        height: .2rem;
+        width: .2rem
+    }
+
+    .md-search__scrollwrap::-webkit-scrollbar-thumb {
+        background-color: rgba(0,0,0,0.32)
+    }
+
+    .md-search__scrollwrap::-webkit-scrollbar-thumb:hover {
+        background-color: #526cfe
+    }
+}
+
+.md-search-result {
+    color: rgba(0,0,0,0.87);
+    word-break: break-word
+}
+
+.md-search-result__meta {
+    background-color: rgba(0,0,0,0.07);
+    color: rgba(0,0,0,0.54);
+    font-size: .64rem;
+    line-height: 1.8rem;
+    padding: 0 .8rem;
+    scroll-snap-align: start
+}
+
+@media screen and (min-width: 60em) {
+    .md-search-result__meta {
+        padding-left:2.2rem
+    }
+
+    [dir=rtl] .md-search-result__meta {
+        padding-left: 0;
+        padding-right: 2.2rem
+    }
+}
+
+.md-search-result__list {
+    list-style: none;
+    margin: 0;
+    padding: 0
+}
+
+.md-search-result__item {
+    box-shadow: 0 -.05rem 0 rgba(0,0,0,0.07)
+}
+
+.md-search-result__item:first-child {
+    box-shadow: none
+}
+
+.md-search-result__link {
+    display: block;
+    outline: none;
+    scroll-snap-align: start;
+    transition: background-color .25s
+}
+
+.md-search-result__link:focus,.md-search-result__link:hover {
+    background-color: rgba(82,108,254,0.1)
+}
+
+.md-search-result__link:last-child p:last-child {
+    margin-bottom: .6rem
+}
+
+.md-search-result__more summary {
+    color: #ef5552;
+    cursor: pointer;
+    display: block;
+    font-size: .64rem;
+    outline: none;
+    padding: .75em .8rem;
+    scroll-snap-align: start;
+    transition: color .25s,background-color .25s
+}
+
+@media screen and (min-width: 60em) {
+    .md-search-result__more summary {
+        padding-left:2.2rem
+    }
+
+    [dir=rtl] .md-search-result__more summary {
+        padding-left: .8rem;
+        padding-right: 2.2rem
+    }
+}
+
+.md-search-result__more summary:focus,.md-search-result__more summary:hover {
+    background-color: rgba(82,108,254,0.1);
+    color: #526cfe
+}
+
+.md-search-result__more summary::-webkit-details-marker,.md-search-result__more summary::marker {
+    display: none
+}
+
+.md-search-result__more summary~*>* {
+    opacity: .65
+}
+
+.md-search-result__article {
+    overflow: hidden;
+    padding: 0 .8rem;
+    position: relative
+}
+
+@media screen and (min-width: 60em) {
+    .md-search-result__article {
+        padding-left:2.2rem
+    }
+
+    [dir=rtl] .md-search-result__article {
+        padding-left: .8rem;
+        padding-right: 2.2rem
+    }
+}
+
+.md-search-result__article--document .md-search-result__title {
+    font-size: .8rem;
+    font-weight: 400;
+    line-height: 1.4;
+    margin: .55rem 0
+}
+
+.md-search-result__icon {
+    color: rgba(0,0,0,0.54);
+    height: 1.2rem;
+    left: 0;
+    margin: .5rem;
+    position: absolute;
+    width: 1.2rem
+}
+
+@media screen and (max-width: 59.9375em) {
+    .md-search-result__icon {
+        display:none
+    }
+}
+
+.md-search-result__icon:after {
+    background-color: currentColor;
+    content: "";
+    display: inline-block;
+    height: 100%;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h7c-.41-.25-.8-.56-1.14-.9-.33-.33-.61-.7-.86-1.1H6V4h7v5h5v1.18c.71.16 1.39.43 2 .82V8l-6-6m6.31 16.9c1.33-2.11.69-4.9-1.4-6.22-2.11-1.33-4.91-.68-6.22 1.4-1.34 2.11-.69 4.89 1.4 6.22 1.46.93 3.32.93 4.79.02L22 23.39 23.39 22l-3.08-3.1m-3.81.1a2.5 2.5 0 0 1-2.5-2.5 2.5 2.5 0 0 1 2.5-2.5 2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1-2.5 2.5z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h7c-.41-.25-.8-.56-1.14-.9-.33-.33-.61-.7-.86-1.1H6V4h7v5h5v1.18c.71.16 1.39.43 2 .82V8l-6-6m6.31 16.9c1.33-2.11.69-4.9-1.4-6.22-2.11-1.33-4.91-.68-6.22 1.4-1.34 2.11-.69 4.89 1.4 6.22 1.46.93 3.32.93 4.79.02L22 23.39 23.39 22l-3.08-3.1m-3.81.1a2.5 2.5 0 0 1-2.5-2.5 2.5 2.5 0 0 1 2.5-2.5 2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1-2.5 2.5z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    width: 100%
+}
+
+[dir=rtl] .md-search-result__icon {
+    left: auto;
+    right: 0
+}
+
+[dir=rtl] .md-search-result__icon:after {
+    transform: scaleX(-1)
+}
+
+.md-search-result__title {
+    font-size: .64rem;
+    font-weight: 700;
+    line-height: 1.6;
+    margin: .5em 0
+}
+
+.md-search-result__teaser {
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    color: rgba(0,0,0,0.54);
+    display: -webkit-box;
+    font-size: .64rem;
+    line-height: 1.6;
+    margin: .5em 0;
+    max-height: 2rem;
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
+@media screen and (max-width: 44.9375em) {
+    .md-search-result__teaser {
+        -webkit-line-clamp:3;
+        max-height: 3rem
+    }
+}
+
+@media screen and (min-width: 60em) and (max-width:76.1875em) {
+    .md-search-result__teaser {
+        -webkit-line-clamp:3;
+        max-height: 3rem
+    }
+}
+
+.md-search-result__teaser mark {
+    background-color: transparent;
+    text-decoration: underline
+}
+
+.md-search-result__terms {
+    font-size: .64rem;
+    font-style: italic;
+    margin: .5em 0
+}
+
+.md-search-result mark {
+    background-color: transparent;
+    color: #526cfe
+}
+
+.md-select {
+    position: relative;
+    z-index: 1
+}
+
+.md-select__inner {
+    background-color: #fff;
+    border-radius: .1rem;
+    box-shadow: 0 .2rem .5rem rgba(0,0,0,.1),0 0 .05rem rgba(0,0,0,.25);
+    color: rgba(0,0,0,0.87);
+    left: 50%;
+    margin-top: .2rem;
+    max-height: 0;
+    opacity: 0;
+    position: absolute;
+    top: calc(100% - .2rem);
+    transform: translate3d(-50%,.3rem,0);
+    transition: transform .25s 375ms,opacity .25s .25s,max-height 0ms .5s
+}
+
+.md-select:focus-within .md-select__inner,.md-select:hover .md-select__inner {
+    max-height: 10rem;
+    opacity: 1;
+    transform: translate3d(-50%,0,0);
+    transition: transform .25s cubic-bezier(.1,.7,.1,1),opacity .25s,max-height 0ms
+}
+
+.md-select__inner:after {
+    border-bottom: .2rem solid transparent;
+    border-bottom-color: #fff;
+    border-left: .2rem solid transparent;
+    border-right: .2rem solid transparent;
+    border-top: 0;
+    content: "";
+    height: 0;
+    left: 50%;
+    margin-left: -.2rem;
+    margin-top: -.2rem;
+    position: absolute;
+    top: 0;
+    width: 0
+}
+
+.md-select__list {
+    border-radius: .1rem;
+    font-size: .8rem;
+    list-style-type: none;
+    margin: 0;
+    max-height: inherit;
+    overflow: auto;
+    padding: 0
+}
+
+.md-select__item {
+    line-height: 1.8rem
+}
+
+.md-select__link {
+    cursor: pointer;
+    display: block;
+    outline: none;
+    padding-left: .6rem;
+    padding-right: 1.2rem;
+    scroll-snap-align: start;
+    transition: background-color .25s,color .25s;
+    width: 100%
+}
+
+[dir=rtl] .md-select__link {
+    padding-left: 1.2rem;
+    padding-right: .6rem
+}
+
+.md-select__link:focus,.md-select__link:hover {
+    color: #526cfe
+}
+
+.md-select__link:focus {
+    background-color: rgba(0,0,0,0.07)
+}
+
+.md-sidebar {
+    align-self: flex-start;
+    flex-shrink: 0;
+    padding: 1.2rem 0;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 2.4rem;
+    width: 12.1rem
+}
+
+@media print {
+    .md-sidebar {
+        display: none
+    }
+}
+
+@media screen and (max-width: 76.1875em) {
+    .md-sidebar--primary {
+        background-color:#fff;
+        display: block;
+        height: 100%;
+        left: -12.1rem;
+        position: fixed;
+        top: 0;
+        transform: translateX(0);
+        transition: transform .25s cubic-bezier(.4,0,.2,1),box-shadow .25s;
+        width: 12.1rem;
+        z-index: 4
+    }
+
+    [dir=rtl] .md-sidebar--primary {
+        left: auto;
+        right: -12.1rem
+    }
+
+    [data-md-toggle=drawer]:checked~.md-container .md-sidebar--primary {
+        box-shadow: 0 8px 10px 1px rgba(0,0,0,.14),0 3px 14px 2px rgba(0,0,0,.12),0 5px 5px -3px rgba(0,0,0,.4);
+        transform: translateX(12.1rem)
+    }
+
+    [dir=rtl] [data-md-toggle=drawer]:checked~.md-container .md-sidebar--primary {
+        transform: translateX(-12.1rem)
+    }
+
+    .md-sidebar--primary .md-sidebar__scrollwrap {
+        bottom: 0;
+        left: 0;
+        margin: 0;
+        overflow: hidden;
+        position: absolute;
+        right: 0;
+        -ms-scroll-snap-type: none;
+        scroll-snap-type: none;
+        top: 0
+    }
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-sidebar {
+        height:0
+    }
+
+    .no-js .md-sidebar {
+        height: auto
+    }
+}
+
+.md-sidebar--secondary {
+    display: none;
+    order: 2
+}
+
+@media screen and (min-width: 60em) {
+    .md-sidebar--secondary {
+        height:0
+    }
+
+    .no-js .md-sidebar--secondary {
+        height: auto
+    }
+
+    .md-sidebar--secondary:not([hidden]) {
+        display: block
+    }
+
+    .md-sidebar--secondary .md-sidebar__scrollwrap {
+        touch-action: pan-y
+    }
+}
+
+.md-sidebar__scrollwrap {
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    margin: 0 .2rem;
+    overflow-y: auto;
+    scrollbar-color: rgba(0,0,0,0.32) transparent;
+    scrollbar-width: thin
+}
+
+.md-sidebar__scrollwrap:hover {
+    scrollbar-color: #526cfe transparent
+}
+
+.md-sidebar__scrollwrap::-webkit-scrollbar {
+    height: .2rem;
+    width: .2rem
+}
+
+.md-sidebar__scrollwrap::-webkit-scrollbar-thumb {
+    background-color: rgba(0,0,0,0.32)
+}
+
+.md-sidebar__scrollwrap::-webkit-scrollbar-thumb:hover {
+    background-color: #526cfe
+}
+
+@media screen and (max-width: 76.1875em) {
+    .md-overlay {
+        background-color:rgba(0,0,0,.54);
+        height: 0;
+        opacity: 0;
+        position: fixed;
+        top: 0;
+        transition: width 0ms .25s,height 0ms .25s,opacity .25s;
+        width: 0;
+        z-index: 4
+    }
+
+    [data-md-toggle=drawer]:checked~.md-overlay {
+        height: 100%;
+        opacity: 1;
+        transition: width 0ms,height 0ms,opacity .25s;
+        width: 100%
+    }
+}
+
+@-webkit-keyframes facts {
+    0% {
+        height: 0
+    }
+
+    to {
+        height: .65rem
+    }
+}
+
+@keyframes facts {
+    0% {
+        height: 0
+    }
+
+    to {
+        height: .65rem
+    }
+}
+
+@-webkit-keyframes fact {
+    0% {
+        opacity: 0;
+        transform: translateY(100%)
+    }
+
+    50% {
+        opacity: 0
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0)
+    }
+}
+
+@keyframes fact {
+    0% {
+        opacity: 0;
+        transform: translateY(100%)
+    }
+
+    50% {
+        opacity: 0
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0)
+    }
+}
+
+.md-source {
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    display: block;
+    font-size: .65rem;
+    line-height: 1.2;
+    outline-color: #526cfe;
+    transition: opacity .25s;
+    white-space: nowrap
+}
+
+.md-source:hover {
+    opacity: .7
+}
+
+.md-source__icon {
+    display: inline-block;
+    height: 2.4rem;
+    vertical-align: middle;
+    width: 2rem
+}
+
+.md-source__icon svg {
+    margin-left: .6rem;
+    margin-top: .6rem
+}
+
+[dir=rtl] .md-source__icon svg {
+    margin-left: 0;
+    margin-right: .6rem
+}
+
+.md-source__icon+.md-source__repository {
+    margin-left: -2rem;
+    padding-left: 2rem
+}
+
+[dir=rtl] .md-source__icon+.md-source__repository {
+    margin-left: 0;
+    margin-right: -2rem;
+    padding-left: 0;
+    padding-right: 2rem
+}
+
+.md-source__repository {
+    display: inline-block;
+    margin-left: .6rem;
+    max-width: calc(100% - 1.2rem);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle
+}
+
+.md-source__facts {
+    font-size: .55rem;
+    list-style-type: none;
+    margin: .1rem 0 0;
+    opacity: .75;
+    overflow: hidden;
+    padding: 0
+}
+
+[data-md-state=done] .md-source__facts {
+    -webkit-animation: facts .25s ease-in;
+    animation: facts .25s ease-in
+}
+
+.md-source__fact {
+    display: inline-block
+}
+
+[data-md-state=done] .md-source__fact {
+    -webkit-animation: fact .4s ease-out;
+    animation: fact .4s ease-out
+}
+
+.md-source__fact:before {
+    background-color: currentColor;
+    content: "";
+    display: inline-block;
+    height: .6rem;
+    margin-right: .1rem;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    vertical-align: text-top;
+    width: .6rem
+}
+
+[dir=rtl] .md-source__fact:before {
+    margin-left: .1rem;
+    margin-right: 0
+}
+
+.md-source__fact:nth-child(1n+2):before {
+    margin-left: .4rem
+}
+
+[dir=rtl] .md-source__fact:nth-child(1n+2):before {
+    margin-left: .1rem;
+    margin-right: .4rem
+}
+
+.md-source__fact--version:before {
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 0 1 .25-.25h5.025a.25.25 0 0 1 .177.073l6.25 6.25a.25.25 0 0 1 0 .354l-5.025 5.025a.25.25 0 0 1-.354 0l-6.25-6.25a.25.25 0 0 1-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 0 1 0 2.474l-5.026 5.026a1.75 1.75 0 0 1-2.474 0l-6.25-6.25A1.75 1.75 0 0 1 1 7.775zM6 5a1 1 0 1 0 0 2 1 1 0 0 0 0-2z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 0 1 .25-.25h5.025a.25.25 0 0 1 .177.073l6.25 6.25a.25.25 0 0 1 0 .354l-5.025 5.025a.25.25 0 0 1-.354 0l-6.25-6.25a.25.25 0 0 1-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 0 1 0 2.474l-5.026 5.026a1.75 1.75 0 0 1-2.474 0l-6.25-6.25A1.75 1.75 0 0 1 1 7.775zM6 5a1 1 0 1 0 0 2 1 1 0 0 0 0-2z"/></svg>');
+}
+
+.md-source__fact--stars:before {
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694v.001z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694v.001z"/></svg>');
+}
+
+.md-source__fact--forks:before {
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm0 2.122a2.25 2.25 0 1 0-1.5 0v.878A2.25 2.25 0 0 0 5.75 8.5h1.5v2.128a2.251 2.251 0 1 0 1.5 0V8.5h1.5a2.25 2.25 0 0 0 2.25-2.25v-.878a2.25 2.25 0 1 0-1.5 0v.878a.75.75 0 0 1-.75.75h-4.5A.75.75 0 0 1 5 6.25v-.878zm3.75 7.378a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm3-8.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm0 2.122a2.25 2.25 0 1 0-1.5 0v.878A2.25 2.25 0 0 0 5.75 8.5h1.5v2.128a2.251 2.251 0 1 0 1.5 0V8.5h1.5a2.25 2.25 0 0 0 2.25-2.25v-.878a2.25 2.25 0 1 0-1.5 0v.878a.75.75 0 0 1-.75.75h-4.5A.75.75 0 0 1 5 6.25v-.878zm3.75 7.378a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm3-8.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5z"/></svg>');
+}
+
+.md-source__fact--repositories:before {
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 1 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 0 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 0 1 1-1h8zM5 12.25v3.25a.25.25 0 0 0 .4.2l1.45-1.087a.25.25 0 0 1 .3 0L8.6 15.7a.25.25 0 0 0 .4-.2v-3.25a.25.25 0 0 0-.25-.25h-3.5a.25.25 0 0 0-.25.25z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 1 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 0 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 0 1 1-1h8zM5 12.25v3.25a.25.25 0 0 0 .4.2l1.45-1.087a.25.25 0 0 1 .3 0L8.6 15.7a.25.25 0 0 0 .4-.2v-3.25a.25.25 0 0 0-.25-.25h-3.5a.25.25 0 0 0-.25.25z"/></svg>');
+}
+
+.md-tabs {
+    background-color: #e53734;
+    color: #fff;
+    overflow: auto;
+    width: 100%
+}
+
+@media print {
+    .md-tabs {
+        display: none
+    }
+}
+
+@media screen and (max-width: 76.1875em) {
+    .md-tabs {
+        display:none
+    }
+}
+
+.md-tabs[data-md-state=hidden] {
+    pointer-events: none
+}
+
+.md-tabs__list {
+    contain: content;
+    list-style: none;
+    margin: 0 0 0 .2rem;
+    padding: 0;
+    white-space: nowrap
+}
+
+[dir=rtl] .md-tabs__list {
+    margin-left: 0;
+    margin-right: .2rem
+}
+
+.md-tabs__item {
+    display: inline-block;
+    height: 2.4rem;
+    padding-left: .6rem;
+    padding-right: .6rem
+}
+
+.md-tabs__link {
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    display: block;
+    font-size: .7rem;
+    margin-top: .8rem;
+    opacity: .7;
+    outline-color: #526cfe;
+    outline-offset: .2rem;
+    transition: transform .4s cubic-bezier(.1,.7,.1,1),opacity .25s
+}
+
+.md-tabs__link--active,.md-tabs__link:focus,.md-tabs__link:hover {
+    color: inherit;
+    opacity: 1
+}
+
+.md-tabs__item:nth-child(2) .md-tabs__link {
+    transition-delay: 20ms
+}
+
+.md-tabs__item:nth-child(3) .md-tabs__link {
+    transition-delay: 40ms
+}
+
+.md-tabs__item:nth-child(4) .md-tabs__link {
+    transition-delay: 60ms
+}
+
+.md-tabs__item:nth-child(5) .md-tabs__link {
+    transition-delay: 80ms
+}
+
+.md-tabs__item:nth-child(6) .md-tabs__link {
+    transition-delay: .1s
+}
+
+.md-tabs__item:nth-child(7) .md-tabs__link {
+    transition-delay: .12s
+}
+
+.md-tabs__item:nth-child(8) .md-tabs__link {
+    transition-delay: .14s
+}
+
+.md-tabs__item:nth-child(9) .md-tabs__link {
+    transition-delay: .16s
+}
+
+.md-tabs__item:nth-child(10) .md-tabs__link {
+    transition-delay: .18s
+}
+
+.md-tabs__item:nth-child(11) .md-tabs__link {
+    transition-delay: .2s
+}
+
+.md-tabs__item:nth-child(12) .md-tabs__link {
+    transition-delay: .22s
+}
+
+.md-tabs__item:nth-child(13) .md-tabs__link {
+    transition-delay: .24s
+}
+
+.md-tabs__item:nth-child(14) .md-tabs__link {
+    transition-delay: .26s
+}
+
+.md-tabs__item:nth-child(15) .md-tabs__link {
+    transition-delay: .28s
+}
+
+.md-tabs__item:nth-child(16) .md-tabs__link {
+    transition-delay: .3s
+}
+
+.md-tabs[data-md-state=hidden] .md-tabs__link {
+    opacity: 0;
+    transform: translateY(50%);
+    transition: transform 0ms .1s,opacity .1s
+}
+
+.md-top {
+    background-color: #fff;
+    border-radius: 1.6rem;
+    box-shadow: 0 .2rem .5rem rgba(0,0,0,.1),0 0 .05rem rgba(0,0,0,.25);
+    color: rgba(0,0,0,0.54);
+    font-size: .7rem;
+    margin-left: 50%;
+    outline: none;
+    padding: .4rem .8rem;
+    position: fixed;
+    top: 3.2rem;
+    transform: translate(-50%);
+    transition: color 125ms,background-color 125ms,transform 125ms cubic-bezier(.4,0,.2,1),opacity 125ms;
+    z-index: 2
+}
+
+@media print {
+    .md-top {
+        display: none
+    }
+}
+
+[dir=rtl] .md-top {
+    float: left
+}
+
+.md-top[data-md-state=hidden] {
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%,.2rem);
+    transition-duration: 0ms
+}
+
+.md-top:focus,.md-top:hover {
+    background-color: #526cfe;
+    color: #fff
+}
+
+.md-top svg {
+    display: inline-block;
+    vertical-align: -.5em
+}
+
+@-webkit-keyframes hoverfix {
+    0% {
+        pointer-events: none
+    }
+}
+
+@keyframes hoverfix {
+    0% {
+        pointer-events: none
+    }
+}
+
+.md-version {
+    flex-shrink: 0;
+    font-size: .8rem;
+    height: 2.4rem
+}
+
+.md-version__current {
+    color: inherit;
+    cursor: pointer;
+    margin-left: 1.4rem;
+    margin-right: .4rem;
+    outline: none;
+    position: relative;
+    top: .05rem
+}
+
+[dir=rtl] .md-version__current {
+    margin-left: .4rem;
+    margin-right: 1.4rem
+}
+
+.md-version__current:after {
+    background-color: currentColor;
+    content: "";
+    display: inline-block;
+    height: .6rem;
+    margin-left: .4rem;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    width: .4rem
+}
+
+[dir=rtl] .md-version__current:after {
+    margin-left: 0;
+    margin-right: .4rem
+}
+
+.md-version__list {
+    background-color: #fff;
+    border-radius: .1rem;
+    box-shadow: 0 .2rem .5rem rgba(0,0,0,.1),0 0 .05rem rgba(0,0,0,.25);
+    color: rgba(0,0,0,0.87);
+    list-style-type: none;
+    margin: .2rem .8rem;
+    max-height: 0;
+    opacity: 0;
+    overflow: auto;
+    padding: 0;
+    position: absolute;
+    -ms-scroll-snap-type: y mandatory;
+    scroll-snap-type: y mandatory;
+    top: .15rem;
+    transition: max-height 0ms .5s,opacity .25s .25s;
+    z-index: 1
+}
+
+.md-version:focus-within .md-version__list,.md-version:hover .md-version__list {
+    max-height: 10rem;
+    opacity: 1;
+    transition: max-height 0ms,opacity .25s
+}
+
+@media (pointer: coarse) {
+    .md-version:hover .md-version__list {
+        -webkit-animation:hoverfix .25s forwards;
+        animation: hoverfix .25s forwards
+    }
+
+    .md-version:focus-within .md-version__list {
+        -webkit-animation: none;
+        animation: none
+    }
+}
+
+.md-version__item {
+    line-height: 1.8rem
+}
+
+.md-version__link {
+    cursor: pointer;
+    display: block;
+    outline: none;
+    padding-left: .6rem;
+    padding-right: 1.2rem;
+    scroll-snap-align: start;
+    transition: color .25s,background-color .25s;
+    white-space: nowrap;
+    width: 100%
+}
+
+[dir=rtl] .md-version__link {
+    padding-left: 1.2rem;
+    padding-right: .6rem
+}
+
+.md-version__link:focus,.md-version__link:hover {
+    color: #526cfe
+}
+
+.md-version__link:focus {
+    background-color: rgba(0,0,0,0.07)
+}
+
+.md-typeset .admonition,.md-typeset details {
+    background-color: #fff;
+    border-left: .2rem solid #448aff;
+    border-radius: .1rem;
+    box-shadow: 0 .2rem .5rem rgba(0,0,0,.05),0 .025rem .05rem rgba(0,0,0,.05);
+    color: rgba(0,0,0,0.87);
+    font-size: .64rem;
+    margin: 1.5625em 0;
+    overflow: hidden;
+    padding: 0 .6rem;
+    page-break-inside: avoid
+}
+
+@media print {
+    .md-typeset .admonition,.md-typeset details {
+        box-shadow: none
+    }
+}
+
+[dir=rtl] .md-typeset .admonition,[dir=rtl] .md-typeset details {
+    border-left: none;
+    border-right: .2rem solid #448aff
+}
+
+.md-typeset .admonition .admonition,.md-typeset .admonition details,.md-typeset details .admonition,.md-typeset details details {
+    margin-bottom: 1em;
+    margin-top: 1em
+}
+
+.md-typeset .admonition .md-typeset__scrollwrap,.md-typeset details .md-typeset__scrollwrap {
+    margin: 1em -.6rem
+}
+
+.md-typeset .admonition .md-typeset__table,.md-typeset details .md-typeset__table {
+    padding: 0 .6rem
+}
+
+.md-typeset .admonition>.tabbed-set:only-child,.md-typeset details>.tabbed-set:only-child {
+    margin-top: 0
+}
+
+html .md-typeset .admonition>:last-child,html .md-typeset details>:last-child {
+    margin-bottom: .6rem
+}
+
+.md-typeset .admonition-title,.md-typeset summary {
+    background-color: rgba(68,138,255,.1);
+    border-left: .2rem solid #448aff;
+    font-weight: 700;
+    margin: 0 -.6rem 0 -.8rem;
+    padding: .4rem .6rem .4rem 2rem;
+    position: relative
+}
+
+[dir=rtl] .md-typeset .admonition-title,[dir=rtl] .md-typeset summary {
+    border-left: none;
+    border-right: .2rem solid #448aff;
+    margin: 0 -.8rem 0 -.6rem;
+    padding: .4rem 2rem .4rem .6rem
+}
+
+html .md-typeset .admonition-title:last-child,html .md-typeset summary:last-child {
+    margin-bottom: 0
+}
+
+.md-typeset .admonition-title:before,.md-typeset summary:before {
+    background-color: #448aff;
+    content: "";
+    height: 1rem;
+    left: .6rem;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    position: absolute;
+    width: 1rem
+}
+
+[dir=rtl] .md-typeset .admonition-title:before,[dir=rtl] .md-typeset summary:before {
+    left: auto;
+    right: .6rem
+}
+
+.md-typeset .admonition-title+.tabbed-set:last-child,.md-typeset summary+.tabbed-set:last-child {
+    margin-top: 0
+}
+
+.md-typeset .admonition.note,.md-typeset details.note {
+    border-color: #448aff
+}
+
+.md-typeset .note>.admonition-title,.md-typeset .note>summary {
+    background-color: rgba(68,138,255,.1);
+    border-color: #448aff
+}
+
+.md-typeset .note>.admonition-title:before,.md-typeset .note>summary:before {
+    background-color: #448aff;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.abstract,.md-typeset .admonition.summary,.md-typeset .admonition.tldr,.md-typeset details.abstract,.md-typeset details.summary,.md-typeset details.tldr {
+    border-color: #00b0ff
+}
+
+.md-typeset .abstract>.admonition-title,.md-typeset .abstract>summary,.md-typeset .summary>.admonition-title,.md-typeset .summary>summary,.md-typeset .tldr>.admonition-title,.md-typeset .tldr>summary {
+    background-color: rgba(0,176,255,.1);
+    border-color: #00b0ff
+}
+
+.md-typeset .abstract>.admonition-title:before,.md-typeset .abstract>summary:before,.md-typeset .summary>.admonition-title:before,.md-typeset .summary>summary:before,.md-typeset .tldr>.admonition-title:before,.md-typeset .tldr>summary:before {
+    background-color: #00b0ff;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17 9H7V7h10m0 6H7v-2h10m-3 6H7v-2h7M12 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1m7 0h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17 9H7V7h10m0 6H7v-2h10m-3 6H7v-2h7M12 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1m7 0h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.info,.md-typeset .admonition.todo,.md-typeset details.info,.md-typeset details.todo {
+    border-color: #00b8d4
+}
+
+.md-typeset .info>.admonition-title,.md-typeset .info>summary,.md-typeset .todo>.admonition-title,.md-typeset .todo>summary {
+    background-color: rgba(0,184,212,.1);
+    border-color: #00b8d4
+}
+
+.md-typeset .info>.admonition-title:before,.md-typeset .info>summary:before,.md-typeset .todo>.admonition-title:before,.md-typeset .todo>summary:before {
+    background-color: #00b8d4;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.hint,.md-typeset .admonition.important,.md-typeset .admonition.tip,.md-typeset details.hint,.md-typeset details.important,.md-typeset details.tip {
+    border-color: #00bfa5
+}
+
+.md-typeset .hint>.admonition-title,.md-typeset .hint>summary,.md-typeset .important>.admonition-title,.md-typeset .important>summary,.md-typeset .tip>.admonition-title,.md-typeset .tip>summary {
+    background-color: rgba(0,191,165,.1);
+    border-color: #00bfa5
+}
+
+.md-typeset .hint>.admonition-title:before,.md-typeset .hint>summary:before,.md-typeset .important>.admonition-title:before,.md-typeset .important>summary:before,.md-typeset .tip>.admonition-title:before,.md-typeset .tip>summary:before {
+    background-color: #00bfa5;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17.66 11.2c-.23-.3-.51-.56-.77-.82-.67-.6-1.43-1.03-2.07-1.66C13.33 7.26 13 4.85 13.95 3c-.95.23-1.78.75-2.49 1.32-2.59 2.08-3.61 5.75-2.39 8.9.04.1.08.2.08.33 0 .22-.15.42-.35.5-.23.1-.47.04-.66-.12a.58.58 0 0 1-.14-.17c-1.13-1.43-1.31-3.48-.55-5.12C5.78 10 4.87 12.3 5 14.47c.06.5.12 1 .29 1.5.14.6.41 1.2.71 1.73 1.08 1.73 2.95 2.97 4.96 3.22 2.14.27 4.43-.12 6.07-1.6 1.83-1.66 2.47-4.32 1.53-6.6l-.13-.26c-.21-.46-.77-1.26-.77-1.26m-3.16 6.3c-.28.24-.74.5-1.1.6-1.12.4-2.24-.16-2.9-.82 1.19-.28 1.9-1.16 2.11-2.05.17-.8-.15-1.46-.28-2.23-.12-.74-.1-1.37.17-2.06.19.38.39.76.63 1.06.77 1 1.98 1.44 2.24 2.8.04.14.06.28.06.43.03.82-.33 1.72-.93 2.27z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17.66 11.2c-.23-.3-.51-.56-.77-.82-.67-.6-1.43-1.03-2.07-1.66C13.33 7.26 13 4.85 13.95 3c-.95.23-1.78.75-2.49 1.32-2.59 2.08-3.61 5.75-2.39 8.9.04.1.08.2.08.33 0 .22-.15.42-.35.5-.23.1-.47.04-.66-.12a.58.58 0 0 1-.14-.17c-1.13-1.43-1.31-3.48-.55-5.12C5.78 10 4.87 12.3 5 14.47c.06.5.12 1 .29 1.5.14.6.41 1.2.71 1.73 1.08 1.73 2.95 2.97 4.96 3.22 2.14.27 4.43-.12 6.07-1.6 1.83-1.66 2.47-4.32 1.53-6.6l-.13-.26c-.21-.46-.77-1.26-.77-1.26m-3.16 6.3c-.28.24-.74.5-1.1.6-1.12.4-2.24-.16-2.9-.82 1.19-.28 1.9-1.16 2.11-2.05.17-.8-.15-1.46-.28-2.23-.12-.74-.1-1.37.17-2.06.19.38.39.76.63 1.06.77 1 1.98 1.44 2.24 2.8.04.14.06.28.06.43.03.82-.33 1.72-.93 2.27z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.check,.md-typeset .admonition.done,.md-typeset .admonition.success,.md-typeset details.check,.md-typeset details.done,.md-typeset details.success {
+    border-color: #00c853
+}
+
+.md-typeset .check>.admonition-title,.md-typeset .check>summary,.md-typeset .done>.admonition-title,.md-typeset .done>summary,.md-typeset .success>.admonition-title,.md-typeset .success>summary {
+    background-color: rgba(0,200,83,.1);
+    border-color: #00c853
+}
+
+.md-typeset .check>.admonition-title:before,.md-typeset .check>summary:before,.md-typeset .done>.admonition-title:before,.md-typeset .done>summary:before,.md-typeset .success>.admonition-title:before,.md-typeset .success>summary:before {
+    background-color: #00c853;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m9 20.42-6.21-6.21 2.83-2.83L9 14.77l9.88-9.89 2.83 2.83L9 20.42z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m9 20.42-6.21-6.21 2.83-2.83L9 14.77l9.88-9.89 2.83 2.83L9 20.42z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.faq,.md-typeset .admonition.help,.md-typeset .admonition.question,.md-typeset details.faq,.md-typeset details.help,.md-typeset details.question {
+    border-color: #64dd17
+}
+
+.md-typeset .faq>.admonition-title,.md-typeset .faq>summary,.md-typeset .help>.admonition-title,.md-typeset .help>summary,.md-typeset .question>.admonition-title,.md-typeset .question>summary {
+    background-color: rgba(100,221,23,.1);
+    border-color: #64dd17
+}
+
+.md-typeset .faq>.admonition-title:before,.md-typeset .faq>summary:before,.md-typeset .help>.admonition-title:before,.md-typeset .help>summary:before,.md-typeset .question>.admonition-title:before,.md-typeset .question>summary:before {
+    background-color: #64dd17;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m15.07 11.25-.9.92C13.45 12.89 13 13.5 13 15h-2v-.5c0-1.11.45-2.11 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41a2 2 0 0 0-2-2 2 2 0 0 0-2 2H8a4 4 0 0 1 4-4 4 4 0 0 1 4 4 3.2 3.2 0 0 1-.93 2.25M13 19h-2v-2h2M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10c0-5.53-4.5-10-10-10z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m15.07 11.25-.9.92C13.45 12.89 13 13.5 13 15h-2v-.5c0-1.11.45-2.11 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41a2 2 0 0 0-2-2 2 2 0 0 0-2 2H8a4 4 0 0 1 4-4 4 4 0 0 1 4 4 3.2 3.2 0 0 1-.93 2.25M13 19h-2v-2h2M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10c0-5.53-4.5-10-10-10z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.attention,.md-typeset .admonition.caution,.md-typeset .admonition.warning,.md-typeset details.attention,.md-typeset details.caution,.md-typeset details.warning {
+    border-color: #ff9100
+}
+
+.md-typeset .attention>.admonition-title,.md-typeset .attention>summary,.md-typeset .caution>.admonition-title,.md-typeset .caution>summary,.md-typeset .warning>.admonition-title,.md-typeset .warning>summary {
+    background-color: rgba(255,145,0,.1);
+    border-color: #ff9100
+}
+
+.md-typeset .attention>.admonition-title:before,.md-typeset .attention>summary:before,.md-typeset .caution>.admonition-title:before,.md-typeset .caution>summary:before,.md-typeset .warning>.admonition-title:before,.md-typeset .warning>summary:before {
+    background-color: #ff9100;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.fail,.md-typeset .admonition.failure,.md-typeset .admonition.missing,.md-typeset details.fail,.md-typeset details.failure,.md-typeset details.missing {
+    border-color: #ff5252
+}
+
+.md-typeset .fail>.admonition-title,.md-typeset .fail>summary,.md-typeset .failure>.admonition-title,.md-typeset .failure>summary,.md-typeset .missing>.admonition-title,.md-typeset .missing>summary {
+    background-color: rgba(255,82,82,.1);
+    border-color: #ff5252
+}
+
+.md-typeset .fail>.admonition-title:before,.md-typeset .fail>summary:before,.md-typeset .failure>.admonition-title:before,.md-typeset .failure>summary:before,.md-typeset .missing>.admonition-title:before,.md-typeset .missing>summary:before {
+    background-color: #ff5252;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 6.91 17.09 4 12 9.09 6.91 4 4 6.91 9.09 12 4 17.09 6.91 20 12 14.91 17.09 20 20 17.09 14.91 12 20 6.91z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 6.91 17.09 4 12 9.09 6.91 4 4 6.91 9.09 12 4 17.09 6.91 20 12 14.91 17.09 20 20 17.09 14.91 12 20 6.91z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.danger,.md-typeset .admonition.error,.md-typeset details.danger,.md-typeset details.error {
+    border-color: #ff1744
+}
+
+.md-typeset .danger>.admonition-title,.md-typeset .danger>summary,.md-typeset .error>.admonition-title,.md-typeset .error>summary {
+    background-color: rgba(255,23,68,.1);
+    border-color: #ff1744
+}
+
+.md-typeset .danger>.admonition-title:before,.md-typeset .danger>summary:before,.md-typeset .error>.admonition-title:before,.md-typeset .error>summary:before {
+    background-color: #ff1744;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M11 15H6l7-14v8h5l-7 14v-8z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M11 15H6l7-14v8h5l-7 14v-8z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.bug,.md-typeset details.bug {
+    border-color: #f50057
+}
+
+.md-typeset .bug>.admonition-title,.md-typeset .bug>summary {
+    background-color: rgba(245,0,87,.1);
+    border-color: #f50057
+}
+
+.md-typeset .bug>.admonition-title:before,.md-typeset .bug>summary:before {
+    background-color: #f50057;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 12h-4v-2h4m0 6h-4v-2h4m6-6h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a6.002 6.002 0 0 0-2.83 0L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 12h-4v-2h4m0 6h-4v-2h4m6-6h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a6.002 6.002 0 0 0-2.83 0L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.example,.md-typeset details.example {
+    border-color: #7c4dff
+}
+
+.md-typeset .example>.admonition-title,.md-typeset .example>summary {
+    background-color: rgba(124,77,255,.1);
+    border-color: #7c4dff
+}
+
+.md-typeset .example>.admonition-title:before,.md-typeset .example>summary:before {
+    background-color: #7c4dff;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7 13v-2h14v2H7m0 6v-2h14v2H7M7 7V5h14v2H7M3 8V5H2V4h2v4H3m-1 9v-1h3v4H2v-1h2v-.5H3v-1h1V17H2m2.25-7a.75.75 0 0 1 .75.75c0 .2-.08.39-.21.52L3.12 13H5v1H2v-.92L4 11H2v-1h2.25z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7 13v-2h14v2H7m0 6v-2h14v2H7M7 7V5h14v2H7M3 8V5H2V4h2v4H3m-1 9v-1h3v4H2v-1h2v-.5H3v-1h1V17H2m2.25-7a.75.75 0 0 1 .75.75c0 .2-.08.39-.21.52L3.12 13H5v1H2v-.92L4 11H2v-1h2.25z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .admonition.cite,.md-typeset .admonition.quote,.md-typeset details.cite,.md-typeset details.quote {
+    border-color: #9e9e9e
+}
+
+.md-typeset .cite>.admonition-title,.md-typeset .cite>summary,.md-typeset .quote>.admonition-title,.md-typeset .quote>summary {
+    background-color: hsla(0,0%,62%,.1);
+    border-color: #9e9e9e
+}
+
+.md-typeset .cite>.admonition-title:before,.md-typeset .cite>summary:before,.md-typeset .quote>.admonition-title:before,.md-typeset .quote>summary:before {
+    background-color: #9e9e9e;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 17h3l2-4V7h-6v6h3M6 17h3l2-4V7H5v6h3l-2 4z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 17h3l2-4V7h-6v6h3M6 17h3l2-4V7H5v6h3l-2 4z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.md-typeset .footnote {
+    color: rgba(0,0,0,0.54);
+    font-size: .64rem
+}
+
+.md-typeset .footnote>ol {
+    margin-left: 0
+}
+
+.md-typeset .footnote>ol>li {
+    transition: color 125ms
+}
+
+.md-typeset .footnote>ol>li:target {
+    color: rgba(0,0,0,0.87)
+}
+
+.md-typeset .footnote>ol>li:hover .footnote-backref,.md-typeset .footnote>ol>li:target .footnote-backref {
+    opacity: 1;
+    transform: translateX(0)
+}
+
+.md-typeset .footnote>ol>li>:first-child {
+    margin-top: 0
+}
+
+.md-typeset .footnote-ref {
+    font-size: .75em;
+    font-weight: 700
+}
+
+html .md-typeset .footnote-ref {
+    outline-offset: .1rem
+}
+
+.md-typeset .footnote-backref {
+    color: #ef5552;
+    display: inline-block;
+    font-size: 0;
+    opacity: 0;
+    transform: translateX(.25rem);
+    transition: color .25s,transform .25s .25s,opacity 125ms .25s;
+    vertical-align: text-bottom
+}
+
+@media print {
+    .md-typeset .footnote-backref {
+        color: #ef5552;
+        opacity: 1;
+        transform: translateX(0)
+    }
+}
+
+[dir=rtl] .md-typeset .footnote-backref {
+    transform: translateX(-.25rem)
+}
+
+.md-typeset .footnote-backref:hover {
+    color: #526cfe
+}
+
+.md-typeset .footnote-backref:before {
+    background-color: currentColor;
+    content: "";
+    display: inline-block;
+    height: .8rem;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.42L5.83 13H21V7h-2z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.42L5.83 13H21V7h-2z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    width: .8rem
+}
+
+[dir=rtl] .md-typeset .footnote-backref:before svg {
+    transform: scaleX(-1)
+}
+
+.md-typeset [id^="fnref:"]:target {
+    margin-top: -3.4rem;
+    padding-top: 3.4rem;
+    scroll-margin-top: 0
+}
+
+.md-typeset [id^="fnref:"]:target>.footnote-ref {
+    outline: auto
+}
+
+.md-typeset [id^="fn:"]:target {
+    margin-top: -3.45rem;
+    padding-top: 3.45rem;
+    scroll-margin-top: 0
+}
+
+.md-typeset .headerlink {
+    color: rgba(0,0,0,0.32);
+    display: inline-block;
+    margin-left: .5rem;
+    opacity: 0;
+    transition: color .25s,opacity 125ms
+}
+
+@media print {
+    .md-typeset .headerlink {
+        display: none
+    }
+}
+
+[dir=rtl] .md-typeset .headerlink {
+    margin-left: 0;
+    margin-right: .5rem
+}
+
+.md-typeset .headerlink:focus,.md-typeset :hover>.headerlink,.md-typeset :target>.headerlink {
+    opacity: 1;
+    transition: color .25s,opacity 125ms
+}
+
+.md-typeset .headerlink:focus,.md-typeset .headerlink:hover,.md-typeset :target>.headerlink {
+    color: #526cfe
+}
+
+.md-typeset :target {
+    scroll-margin-top: 3.6rem
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-header--lifted~.md-container .md-typeset :target {
+        scroll-margin-top:6rem
+    }
+}
+
+.md-typeset h1:target,.md-typeset h2:target,.md-typeset h3:target {
+    scroll-margin-top: 0
+}
+
+.md-typeset h1:target:before,.md-typeset h2:target:before,.md-typeset h3:target:before {
+    content: "";
+    display: block;
+    margin-top: -3.4rem;
+    padding-top: 3.4rem
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-header--lifted~.md-container .md-typeset h1:target,.md-header--lifted~.md-container .md-typeset h2:target,.md-header--lifted~.md-container .md-typeset h3:target {
+        scroll-margin-top:0
+    }
+
+    .md-header--lifted~.md-container .md-typeset h1:target:before,.md-header--lifted~.md-container .md-typeset h2:target:before,.md-header--lifted~.md-container .md-typeset h3:target:before {
+        margin-top: -5.8rem;
+        padding-top: 5.8rem
+    }
+}
+
+.md-typeset h4:target {
+    scroll-margin-top: 0
+}
+
+.md-typeset h4:target:before {
+    content: "";
+    display: block;
+    margin-top: -3.45rem;
+    padding-top: 3.45rem
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-header--lifted~.md-container .md-typeset h4:target {
+        scroll-margin-top:0
+    }
+
+    .md-header--lifted~.md-container .md-typeset h4:target:before {
+        margin-top: -5.85rem;
+        padding-top: 5.85rem
+    }
+}
+
+.md-typeset h5:target,.md-typeset h6:target {
+    scroll-margin-top: 0
+}
+
+.md-typeset h5:target:before,.md-typeset h6:target:before {
+    content: "";
+    display: block;
+    margin-top: -3.6rem;
+    padding-top: 3.6rem
+}
+
+@media screen and (min-width: 76.25em) {
+    .md-header--lifted~.md-container .md-typeset h5:target,.md-header--lifted~.md-container .md-typeset h6:target {
+        scroll-margin-top:0
+    }
+
+    .md-header--lifted~.md-container .md-typeset h5:target:before,.md-header--lifted~.md-container .md-typeset h6:target:before {
+        margin-top: -6rem;
+        padding-top: 6rem
+    }
+}
+
+.md-typeset div.arithmatex {
+    overflow: auto
+}
+
+@media screen and (max-width: 44.9375em) {
+    .md-typeset div.arithmatex {
+        margin:0 -.8rem
+    }
+}
+
+.md-typeset div.arithmatex>* {
+    margin: 1em auto!important;
+    padding: 0 .8rem;
+    touch-action: auto;
+    width: -webkit-min-content;
+    width: -moz-min-content;
+    width: min-content
+}
+
+.md-typeset .critic.comment,.md-typeset del.critic,.md-typeset ins.critic {
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone
+}
+
+.md-typeset del.critic {
+    background-color: hsla(6,90%,60%,0.15)
+}
+
+.md-typeset ins.critic {
+    background-color: rgba(11,213,112,0.15)
+}
+
+.md-typeset .critic.comment {
+    color: rgba(0,0,0,0.54)
+}
+
+.md-typeset .critic.comment:before {
+    content: "/* "
+}
+
+.md-typeset .critic.comment:after {
+    content: " */"
+}
+
+.md-typeset .critic.block {
+    box-shadow: none;
+    display: block;
+    margin: 1em 0;
+    overflow: auto;
+    padding-left: .8rem;
+    padding-right: .8rem
+}
+
+.md-typeset .critic.block>:first-child {
+    margin-top: .5em
+}
+
+.md-typeset .critic.block>:last-child {
+    margin-bottom: .5em
+}
+
+.md-typeset details {
+    display: flow-root;
+    overflow: visible;
+    padding-top: 0
+}
+
+.md-typeset details[open]>summary:after {
+    transform: rotate(90deg)
+}
+
+.md-typeset details:not([open]) {
+    box-shadow: none;
+    padding-bottom: 0
+}
+
+.md-typeset details:not([open])>summary {
+    border-radius: .1rem
+}
+
+.md-typeset details:after {
+    content: "";
+    display: table
+}
+
+.md-typeset summary {
+    border-top-left-radius: .1rem;
+    border-top-right-radius: .1rem;
+    cursor: pointer;
+    display: block;
+    min-height: 1rem;
+    padding: .4rem 1.8rem .4rem 2rem
+}
+
+[dir=rtl] .md-typeset summary {
+    padding: .4rem 2.2rem .4rem 1.8rem
+}
+
+.md-typeset summary.focus-visible {
+    outline-color: #526cfe;
+    outline-offset: .2rem
+}
+
+.md-typeset summary:not(.focus-visible) {
+    -webkit-tap-highlight-color: transparent;
+    outline: none
+}
+
+.md-typeset summary:after {
+    background-color: currentColor;
+    content: "";
+    height: 1rem;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    position: absolute;
+    right: .4rem;
+    top: .4rem;
+    transform: rotate(0deg);
+    transition: transform .25s;
+    width: 1rem
+}
+
+[dir=rtl] .md-typeset summary:after {
+    left: .4rem;
+    right: auto;
+    transform: rotate(180deg)
+}
+
+.md-typeset summary::-webkit-details-marker,.md-typeset summary::marker {
+    display: none
+}
+
+.md-typeset .emojione,.md-typeset .gemoji,.md-typeset .twemoji {
+    display: inline-flex;
+    height: 1.125em;
+    vertical-align: text-top
+}
+
+.md-typeset .emojione svg,.md-typeset .gemoji svg,.md-typeset .twemoji svg {
+    fill: currentColor;
+    max-height: 100%;
+    width: 1.125em
+}
+
+.highlight .o,.highlight .ow {
+    color: rgba(0,0,0,0.54)
+}
+
+.highlight .p {
+    color: rgba(0,0,0,0.54)
+}
+
+.highlight .cpf,.highlight .l,.highlight .s,.highlight .s1,.highlight .s2,.highlight .sb,.highlight .sc,.highlight .si,.highlight .ss {
+    color: #1c7d4d
+}
+
+.highlight .cp,.highlight .se,.highlight .sh,.highlight .sr,.highlight .sx {
+    color: #db1457
+}
+
+.highlight .il,.highlight .m,.highlight .mb,.highlight .mf,.highlight .mh,.highlight .mi,.highlight .mo {
+    color: #d52a2a
+}
+
+.highlight .k,.highlight .kd,.highlight .kn,.highlight .kp,.highlight .kr,.highlight .kt {
+    color: #3f6ec6
+}
+
+.highlight .kc,.highlight .n {
+    color: #36464e
+}
+
+.highlight .bp,.highlight .nb,.highlight .no {
+    color: #6e59d9
+}
+
+.highlight .nc,.highlight .ne,.highlight .nf,.highlight .nn {
+    color: #a846b9
+}
+
+.highlight .nd,.highlight .ni,.highlight .nl,.highlight .nt {
+    color: #3f6ec6
+}
+
+.highlight .c,.highlight .c1,.highlight .ch,.highlight .cm,.highlight .cs,.highlight .sd {
+    color: rgba(0,0,0,0.54)
+}
+
+.highlight .na,.highlight .nv,.highlight .vc,.highlight .vg,.highlight .vi {
+    color: rgba(0,0,0,0.54)
+}
+
+.highlight .ge,.highlight .gh,.highlight .go,.highlight .gp,.highlight .gr,.highlight .gs,.highlight .gt,.highlight .gu {
+    color: rgba(0,0,0,0.54)
+}
+
+.highlight .gd,.highlight .gi {
+    border-radius: .1rem;
+    margin: 0 -.125em;
+    padding: 0 .125em
+}
+
+.highlight .gd {
+    background-color: hsla(6,90%,60%,0.15)
+}
+
+.highlight .gi {
+    background-color: rgba(11,213,112,0.15)
+}
+
+.highlight .hll {
+    background-color: rgba(255,255,0,0.5);
+    display: block;
+    margin: 0 -1.1764705882em;
+    padding: 0 1.1764705882em
+}
+
+.highlight [data-linenos]:before {
+    background-color: #f5f5f5;
+    box-shadow: -.05rem 0 rgba(0,0,0,0.07) inset;
+    color: rgba(0,0,0,0.54);
+    content: attr(data-linenos);
+    float: left;
+    left: -1.1764705882em;
+    margin-left: -1.1764705882em;
+    margin-right: 1.1764705882em;
+    padding-left: 1.1764705882em;
+    position: -webkit-sticky;
+    position: sticky;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none
+}
+
+.highlighttable {
+    display: flow-root;
+    overflow: hidden
+}
+
+.highlighttable tbody,.highlighttable td {
+    display: block;
+    padding: 0
+}
+
+.highlighttable tr {
+    display: flex
+}
+
+.highlighttable pre {
+    margin: 0
+}
+
+.highlighttable .linenos {
+    background-color: #f5f5f5;
+    font-size: .85em;
+    padding: .7720588235em 0 .7720588235em 1.1764705882em;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none
+}
+
+.highlighttable .linenodiv {
+    box-shadow: -.05rem 0 rgba(0,0,0,0.07) inset;
+    padding-right: .5882352941em
+}
+
+.highlighttable .linenodiv pre {
+    color: rgba(0,0,0,0.54);
+    text-align: right
+}
+
+.highlighttable .code {
+    flex: 1;
+    overflow: hidden
+}
+
+.md-typeset .highlighttable {
+    border-radius: .1rem;
+    direction: ltr;
+    margin: 1em 0
+}
+
+.md-typeset .highlighttable code {
+    border-radius: 0
+}
+
+@media screen and (max-width: 44.9375em) {
+    .md-typeset>.highlight {
+        margin:1em -.8rem
+    }
+
+    .md-typeset>.highlight .hll {
+        margin: 0 -.8rem;
+        padding: 0 .8rem
+    }
+
+    .md-typeset>.highlight code {
+        border-radius: 0
+    }
+
+    .md-typeset>.highlighttable {
+        border-radius: 0;
+        margin: 1em -.8rem
+    }
+
+    .md-typeset>.highlighttable .hll {
+        margin: 0 -.8rem;
+        padding: 0 .8rem
+    }
+}
+
+.md-typeset .keys kbd:after,.md-typeset .keys kbd:before {
+    -moz-osx-font-smoothing: initial;
+    -webkit-font-smoothing: initial;
+    color: inherit;
+    margin: 0;
+    position: relative
+}
+
+.md-typeset .keys span {
+    color: rgba(0,0,0,0.54);
+    padding: 0 .2em
+}
+
+.md-typeset .keys .key-alt:before {
+    content: "⎇";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-left-alt:before {
+    content: "⎇";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-right-alt:before {
+    content: "⎇";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-command:before {
+    content: "⌘";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-left-command:before {
+    content: "⌘";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-right-command:before {
+    content: "⌘";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-control:before {
+    content: "⌃";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-left-control:before {
+    content: "⌃";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-right-control:before {
+    content: "⌃";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-meta:before {
+    content: "◆";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-left-meta:before {
+    content: "◆";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-right-meta:before {
+    content: "◆";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-option:before {
+    content: "⌥";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-left-option:before {
+    content: "⌥";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-right-option:before {
+    content: "⌥";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-shift:before {
+    content: "⇧";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-left-shift:before {
+    content: "⇧";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-right-shift:before {
+    content: "⇧";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-super:before {
+    content: "❖";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-left-super:before {
+    content: "❖";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-right-super:before {
+    content: "❖";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-windows:before {
+    content: "⊞";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-left-windows:before {
+    content: "⊞";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-right-windows:before {
+    content: "⊞";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-arrow-down:before {
+    content: "↓";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-arrow-left:before {
+    content: "←";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-arrow-right:before {
+    content: "→";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-arrow-up:before {
+    content: "↑";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-backspace:before {
+    content: "⌫";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-backtab:before {
+    content: "⇤";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-caps-lock:before {
+    content: "⇪";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-clear:before {
+    content: "⌧";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-context-menu:before {
+    content: "☰";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-delete:before {
+    content: "⌦";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-eject:before {
+    content: "⏏";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-end:before {
+    content: "⤓";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-escape:before {
+    content: "⎋";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-home:before {
+    content: "⤒";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-insert:before {
+    content: "⎀";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-page-down:before {
+    content: "⇟";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-page-up:before {
+    content: "⇞";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-print-screen:before {
+    content: "⎙";
+    padding-right: .4em
+}
+
+.md-typeset .keys .key-tab:after {
+    content: "⇥";
+    padding-left: .4em
+}
+
+.md-typeset .keys .key-num-enter:after {
+    content: "⌤";
+    padding-left: .4em
+}
+
+.md-typeset .keys .key-enter:after {
+    content: "⏎";
+    padding-left: .4em
+}
+
+.md-typeset .tabbed-content {
+    box-shadow: 0 -.05rem rgba(0,0,0,0.07);
+    display: none;
+    order: 99;
+    width: 100%
+}
+
+@media print {
+    .md-typeset .tabbed-content {
+        display: block;
+        order: 0
+    }
+}
+
+.md-typeset .tabbed-content>.highlight:only-child pre,.md-typeset .tabbed-content>.highlighttable:only-child,.md-typeset .tabbed-content>pre:only-child {
+    margin: 0
+}
+
+.md-typeset .tabbed-content>.highlight:only-child pre>code,.md-typeset .tabbed-content>.highlighttable:only-child>code,.md-typeset .tabbed-content>pre:only-child>code {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0
+}
+
+.md-typeset .tabbed-content>.tabbed-set {
+    margin: 0
+}
+
+.md-typeset .tabbed-set {
+    border-radius: .1rem;
+    display: flex;
+    flex-wrap: wrap;
+    margin: 1em 0;
+    position: relative
+}
+
+.md-typeset .tabbed-set>input {
+    height: 0;
+    opacity: 0;
+    position: absolute;
+    width: 0
+}
+
+.md-typeset .tabbed-set>input:checked+label {
+    border-color: #526cfe;
+    color: #526cfe
+}
+
+.md-typeset .tabbed-set>input:checked+label+.tabbed-content {
+    display: block
+}
+
+.md-typeset .tabbed-set>input:focus+label {
+    outline-color: #526cfe;
+    outline-style: auto
+}
+
+.md-typeset .tabbed-set>input:not(.focus-visible)+label {
+    -webkit-tap-highlight-color: transparent;
+    outline: none
+}
+
+.md-typeset .tabbed-set>label {
+    border-bottom: .1rem solid transparent;
+    color: rgba(0,0,0,0.54);
+    cursor: pointer;
+    font-size: .64rem;
+    font-weight: 700;
+    padding: .9375em 1.25em .78125em;
+    transition: color .25s;
+    width: auto;
+    z-index: 1
+}
+
+.md-typeset .tabbed-set>label:hover {
+    color: #526cfe
+}
+
+@media screen {
+    .md-typeset .tabbed-alternate input:first-child:checked~.tabbed-labels>:first-child,.md-typeset .tabbed-alternate input:nth-child(2):checked~.tabbed-labels>:nth-child(2),.md-typeset .tabbed-alternate input:nth-child(3):checked~.tabbed-labels>:nth-child(3),.md-typeset .tabbed-alternate input:nth-child(4):checked~.tabbed-labels>:nth-child(4),.md-typeset .tabbed-alternate input:nth-child(5):checked~.tabbed-labels>:nth-child(5),.md-typeset .tabbed-alternate input:nth-child(6):checked~.tabbed-labels>:nth-child(6),.md-typeset .tabbed-alternate input:nth-child(7):checked~.tabbed-labels>:nth-child(7),.md-typeset .tabbed-alternate input:nth-child(8):checked~.tabbed-labels>:nth-child(8),.md-typeset .tabbed-alternate input:nth-child(9):checked~.tabbed-labels>:nth-child(9),.md-typeset .tabbed-alternate input:nth-child(10):checked~.tabbed-labels>:nth-child(10) {
+        border-color: #526cfe;
+        color: #526cfe
+    }
+}
+
+.md-typeset .tabbed-alternate input:first-child.focus-visible~.tabbed-labels>:first-child,.md-typeset .tabbed-alternate input:nth-child(2).focus-visible~.tabbed-labels>:nth-child(2),.md-typeset .tabbed-alternate input:nth-child(3).focus-visible~.tabbed-labels>:nth-child(3),.md-typeset .tabbed-alternate input:nth-child(4).focus-visible~.tabbed-labels>:nth-child(4),.md-typeset .tabbed-alternate input:nth-child(5).focus-visible~.tabbed-labels>:nth-child(5),.md-typeset .tabbed-alternate input:nth-child(6).focus-visible~.tabbed-labels>:nth-child(6),.md-typeset .tabbed-alternate input:nth-child(7).focus-visible~.tabbed-labels>:nth-child(7),.md-typeset .tabbed-alternate input:nth-child(8).focus-visible~.tabbed-labels>:nth-child(8),.md-typeset .tabbed-alternate input:nth-child(9).focus-visible~.tabbed-labels>:nth-child(9),.md-typeset .tabbed-alternate input:nth-child(10).focus-visible~.tabbed-labels>:nth-child(10) {
+    background-color: rgba(82,108,254,0.1)
+}
+
+.md-typeset .tabbed-alternate input:first-child:checked~.tabbed-content>:first-child,.md-typeset .tabbed-alternate input:nth-child(2):checked~.tabbed-content>:nth-child(2),.md-typeset .tabbed-alternate input:nth-child(3):checked~.tabbed-content>:nth-child(3),.md-typeset .tabbed-alternate input:nth-child(4):checked~.tabbed-content>:nth-child(4),.md-typeset .tabbed-alternate input:nth-child(5):checked~.tabbed-content>:nth-child(5),.md-typeset .tabbed-alternate input:nth-child(6):checked~.tabbed-content>:nth-child(6),.md-typeset .tabbed-alternate input:nth-child(7):checked~.tabbed-content>:nth-child(7),.md-typeset .tabbed-alternate input:nth-child(8):checked~.tabbed-content>:nth-child(8),.md-typeset .tabbed-alternate input:nth-child(9):checked~.tabbed-content>:nth-child(9),.md-typeset .tabbed-alternate input:nth-child(10):checked~.tabbed-content>:nth-child(10) {
+    display: block
+}
+
+.md-typeset .tabbed-labels {
+    -ms-overflow-style: none;
+    box-shadow: 0 -.05rem rgba(0,0,0,0.07) inset;
+    display: flex;
+    max-width: 100vw;
+    overflow: auto;
+    -ms-scroll-snap-type: x proximity;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none
+}
+
+@media print {
+    .md-typeset .tabbed-labels {
+        display: contents
+    }
+}
+
+.md-typeset .tabbed-labels::-webkit-scrollbar {
+    display: none
+}
+
+.md-typeset .tabbed-labels>label {
+    border-bottom: .1rem solid transparent;
+    border-top-left-radius: .1rem;
+    border-top-right-radius: .1rem;
+    color: rgba(0,0,0,0.54);
+    cursor: pointer;
+    font-size: .64rem;
+    font-weight: 700;
+    padding: .9375em 1.25em .78125em;
+    scroll-snap-align: start;
+    transition: background-color .25s,color .25s;
+    white-space: nowrap;
+    width: auto;
+    z-index: 1
+}
+
+@media print {
+    .md-typeset .tabbed-labels>label:first-child {
+        order: 1
+    }
+
+    .md-typeset .tabbed-labels>label:nth-child(2) {
+        order: 2
+    }
+
+    .md-typeset .tabbed-labels>label:nth-child(3) {
+        order: 3
+    }
+
+    .md-typeset .tabbed-labels>label:nth-child(4) {
+        order: 4
+    }
+
+    .md-typeset .tabbed-labels>label:nth-child(5) {
+        order: 5
+    }
+
+    .md-typeset .tabbed-labels>label:nth-child(6) {
+        order: 6
+    }
+
+    .md-typeset .tabbed-labels>label:nth-child(7) {
+        order: 7
+    }
+
+    .md-typeset .tabbed-labels>label:nth-child(8) {
+        order: 8
+    }
+
+    .md-typeset .tabbed-labels>label:nth-child(9) {
+        order: 9
+    }
+
+    .md-typeset .tabbed-labels>label:nth-child(10) {
+        order: 10
+    }
+}
+
+.md-typeset .tabbed-labels>label:hover {
+    color: #526cfe
+}
+
+@media screen and (max-width: 44.9375em) {
+    .md-typeset>.tabbed-alternate .tabbed-labels {
+        margin:0 -.8rem;
+        padding: 0 .8rem;
+        scroll-padding: 0 .8rem
+    }
+}
+
+.md-typeset .tabbed-alternate {
+    flex-direction: column
+}
+
+.md-typeset .tabbed-alternate .tabbed-content {
+    box-shadow: none;
+    display: initial;
+    order: 0;
+    width: 100%
+}
+
+@media print {
+    .md-typeset .tabbed-alternate .tabbed-content {
+        display: contents
+    }
+}
+
+.md-typeset .tabbed-alternate .tabbed-block {
+    display: none
+}
+
+@media print {
+    .md-typeset .tabbed-alternate .tabbed-block {
+        display: block
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:first-child {
+        order: 1
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:nth-child(2) {
+        order: 2
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:nth-child(3) {
+        order: 3
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:nth-child(4) {
+        order: 4
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:nth-child(5) {
+        order: 5
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:nth-child(6) {
+        order: 6
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:nth-child(7) {
+        order: 7
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:nth-child(8) {
+        order: 8
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:nth-child(9) {
+        order: 9
+    }
+
+    .md-typeset .tabbed-alternate .tabbed-block:nth-child(10) {
+        order: 10
+    }
+}
+
+.md-typeset .tabbed-alternate .tabbed-block>.highlight:only-child pre,.md-typeset .tabbed-alternate .tabbed-block>.highlighttable:only-child,.md-typeset .tabbed-alternate .tabbed-block>pre:only-child {
+    margin: 0
+}
+
+.md-typeset .tabbed-alternate .tabbed-block>.highlight:only-child pre>code,.md-typeset .tabbed-alternate .tabbed-block>.highlighttable:only-child>code,.md-typeset .tabbed-alternate .tabbed-block>pre:only-child>code {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0
+}
+
+.md-typeset .tabbed-alternate .tabbed-block>.tabbed-set {
+    margin: 0
+}
+
+.md-typeset .task-list-item {
+    list-style-type: none;
+    position: relative
+}
+
+.md-typeset .task-list-item [type=checkbox] {
+    left: -2em;
+    position: absolute;
+    top: .45em
+}
+
+[dir=rtl] .md-typeset .task-list-item [type=checkbox] {
+    left: auto;
+    right: -2em
+}
+
+.md-typeset .task-list-control [type=checkbox] {
+    opacity: 0;
+    z-index: -1
+}
+
+.md-typeset .task-list-indicator:before {
+    background-color: rgba(0,0,0,0.07);
+    content: "";
+    height: 1.25em;
+    left: -1.5em;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm16.28-2.72a.75.75 0 0 0-1.06-1.06l-5.97 5.97-2.47-2.47a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l6.5-6.5z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm16.28-2.72a.75.75 0 0 0-1.06-1.06l-5.97 5.97-2.47-2.47a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l6.5-6.5z"/></svg>');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    position: absolute;
+    top: .15em;
+    width: 1.25em
+}
+
+[dir=rtl] .md-typeset .task-list-indicator:before {
+    left: auto;
+    right: -1.5em
+}
+
+.md-typeset [type=checkbox]:checked+.task-list-indicator:before {
+    background-color: #00e676;
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm16.28-2.72a.75.75 0 0 0-1.06-1.06l-5.97 5.97-2.47-2.47a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l6.5-6.5z"/></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm16.28-2.72a.75.75 0 0 0-1.06-1.06l-5.97 5.97-2.47-2.47a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l6.5-6.5z"/></svg>')
+}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,9 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - javascript/ie_compatibility.js
+
 nav:
   - Home: index.md
   - 행동 규칙 : Hacktoberfest_code_of_conduct.md


### PR DESCRIPTION
원인 
IE에서 일부 css 코드가 정상적으로 동작하지 않음 -> IE에서 css에서 변수기능 지원 안함 : [참고](https://caniuse.com/css-variables)

처리
1. js파일을 로드하고 IE인지 확인
2. IE일경우 ie대응용 css파일을 추가로 로드한다. (ie대응용 파일 : css파일에 var코드로 적용된 컬러를 원래 컬러코드로 대입함)

추가 이슈
기존에도 IE에서는 '자주 묻는 질문' 페이지에 아이콘이 정상적으로 노출되지 않음 -> mask-image속성이 IE에서 지원하지 않아 발생하는듯 : [참고](https://caniuse.com/mdn-css_properties_mask-image)

** mkdocs-material 버젼을 업그레이드 시키면 해결이 될 수도 있지않을까요?
[Upgrading from 4.x to 5.x](https://squidfunk.github.io/mkdocs-material/upgrading/#upgrading-from-4x-to-5x) 
-> Reduced HTML and CSS footprint due to deprecation of Internet Explorer support